### PR TITLE
Reconfigure Antora to pull content from tags

### DIFF
--- a/.github/CONTRIBUTING.adoc
+++ b/.github/CONTRIBUTING.adoc
@@ -2,6 +2,7 @@
 :url-node: https://nodejs.org/en/download/
 :url-imdg-docs: https://github.com/hazelcast/imdg-docs
 :url-antora-yml: https://docs.antora.org/antora/2.3/component-version-descriptor
+:url-readme: ../README.adoc
 :toc: preamble
 
 The Hazelcast docs are open source, and we welcome your contributions!
@@ -25,7 +26,7 @@ If no version number is displayed in the output, you need to {url-node}[install 
 
 === Step 2. Clone a documentation project
 
-Documentation is hosted in separate GitHub repositorites. So, to work on a particular documentation project, you must fork it, clone it, and configure the `antora-playbook-local.yml` file to process your local version.
+Documentation is hosted in {url-readme}#documentation-content[separate GitHub repositorites]. So, to work on a particular documentation project, you must fork it, clone it, and configure the `antora-playbook-local.yml` file to process your local version.
 
 NOTE: You can find all content repositories in the `antora-playbook.yml` file under `content.sources`.
 
@@ -184,29 +185,4 @@ npm run-script build-local
 NOTE: This script is defined in the `package.json` file, and runs Antora with the `antora-playbook-local.yml` file.
 +
 In the `docs` folder you will now have all the webpages for your documentation component.
-
-== Release a new version of a docs component
-
-Documentation components are hosted in their own repositories, using the following branches:
-
-- `main`/`master`: Documentation for the latest development version of the product
-- `v\{version\}`: Documentation for the latest stable version of the product
-- `archive`: Documentation for old versions of the product
-
-To release a new version, you must do the following:
-
-. In the `main`/`master` branch of your component's repository, update the `version` field of the `docs/antora.yml` file to the new development version.
-
-. Create a new branch based on `main`/`master` and name it `v\{version\}`.
-+
-TIP: Replace the `version` placeholder with the version of the product that you are releasing.
-+
-NOTE: Antora will automatically build content that is in a branch named with the `v` prefix.
-
-. In your new branch, delete the `prerelease` field in the `docs/antora.yml` file and remove the `-SNAPSHOT` suffix from the `version` field.
-
-. In the `develop` branch of the `hazelcast/hazelcast-docs` repository, update the version numbers of your component in the `_redirects` file.
-+
-NOTE: This file is used to alias the `latest` and `latest-dev` paths in URLS.
-+
 

--- a/.github/CONTRIBUTING.adoc
+++ b/.github/CONTRIBUTING.adoc
@@ -42,13 +42,6 @@ git clone https://github.com/<your-username>/imdg-docs
 cd imdg-docs
 ----
 
-. Create a new local branch for your work.
-+
-[source,bash]
-----
-git checkout -b add-my-awesome-feature
-----
-
 === Step 3. Make your Changes
 
 After installing the dependencies and cloning a documentation project, you're ready to make your changes.
@@ -146,7 +139,7 @@ modules/ <2>
 ----
 <1> This file tells Antora that the contents of the `modules/` folder should be processed and added to the documentation site. This file is called the {url-antora-yml}[component version descriptor file].
 <2> This folder contains the content that Antora will process
-<3> This folder contains any content that can't be categorized uner a specfic module name. Unlike other modules, the name of this module is never displayed in the URL of the site.
+<3> This folder contains any content that can't be categorized under a specfic module name. Unlike other modules, the name of this module is never displayed in the URL of the site.
 <4> In any module, this folder contains downloadable content such as ZIP files that a user can download through a link.
 <5> In any module, this folder contains examples such as source code that you can include in Asciidoc pages.
 <6> In any module, this folder contains images that you can include in Asciidoc pages.

--- a/README.adoc
+++ b/README.adoc
@@ -26,7 +26,7 @@ image::images/docs-preview.png[Preview of the documentation site]
 
 Antora is a static site generator that facilitates a docs-as-code workflow where documentation is stored in Git repositories and processed to output a static website.
 
-Documentation can be stored in one or more repositories and/or branches.
+Documentation can be stored in one or more repositories, using either branches or tags to version it.
 
 Antora uses Asciidoctor.js to convert Asciidoc to HTML, then it uses Handlebars to set that HTML into a page layout.
 
@@ -45,10 +45,20 @@ This project has two playbook files, which configure the build process for the d
 - `antora-playbook-local.yml`: link:{url-contributing}#local-builds[For local builds]
 - `antora-playbook.yml`: For production builds
 
-The current playbooks pull from the following content sources:
+== Documentation Content
 
-- The `master`, `archive`, and all `v` branches of the {url-imdg-docs}[`imdg-docs` repository] and the {url-mc-docs}[`mc-docs` repository]
-- The `home/` folder in this repository, which contains an Antora component for the home page
+The current playbooks pull from the following content repositories:
+
+- {url-imdg-docs}[IMDG documentation]
+- {url-mc-docs}[Management Center documentation]
+
+Inside these repositories, content is stored in the following:
+
+- `master/main` branch: The `lastest-dev` content, which represents the current development version of the product
+- `archive` branch: Legacy content that is not hosted on Antora, but instead given a single page with a link to the legacy documentation site
+- Tags prefixed with `v`: Versioned releases
+
+NOTE: To learn about the release workflow, see the contributing guidelines of a content repository.
 
 [[home]]
 == Home Component
@@ -85,17 +95,17 @@ To automate some elements of the build process, this repository includes the fol
 |Once per day at 00:00 UTC
 |===
 
-As well as these actions, repositories that are listed under the `content.sources` field in the `antora-playbook.yml` file also include GitHub actions to trigger builds of the staging site.
+As well as these actions, content repositories that are listed under the `content.sources` field in the `antora-playbook.yml` file also include GitHub actions to trigger builds of the staging and production site.
 
 ```yaml
 content:
   sources: 
   - url: https://github.com/hazelcast/imdg-docs
-    branches: [master, v*]
+    branches: [master]
     start_path: docs
 ```
 
-Whenever content in the repository's listed branches are changed, the GitHub Action sends a {url-netlify-docs}/configure-builds/build-hooks/[build hook] to Netlify to trigger a new build of the staging site.
+Whenever content in the repository's listed branches/tags are changed, the GitHub Action sends a {url-netlify-docs}/configure-builds/build-hooks/[build hook] to Netlify to trigger a new build of the staging site.
 
 For an example of these GitHub Actions, see the {url-imdg-docs}[IMDG documentation repository].
 

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -23,7 +23,8 @@ content:
     branches: [archive]
     start_paths: docs/*
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [main, v*]
+    branches: [main]
+    tags: [v*]
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs #../mc-docs
     branches: [archive] #branches: HEAD

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -13,7 +13,11 @@ content:
     start_path: home
     branches: HEAD
   - url: https://github.com/hazelcast/imdg-docs
-    branches: [master, v*]
+    branches: [master]
+    tags: [v*, "!v4.0*" , "!v3.12", "!v3.12.1", "!v3.12.2", "!v3.12.3",
+    "!v3.12.4", "!v3.12.5*", "!v3.12.6", "!v3.12.7", "!v3.12.8", "!v3.12.9",
+    "!v3.12.11", "!v3.11*", "!v3.10*", "!v3.9*", "!v3.8*", "!v3.7*", "!v3.6*",
+    "!v3.5*", "!v3.4*", "!v3.3*", "!v*-BETA*"]
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
     branches: [archive]
@@ -26,7 +30,7 @@ content:
     start_paths: docs/*
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.4.5/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.4.6/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -23,7 +23,8 @@ content:
     branches: [archive]
     start_paths: docs/*
   - url: https://github.com/hazelcast/management-center-docs
-    branches: [main, v*]
+    branches: [main]
+    tags: [v*]
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
     branches: [archive]

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -13,7 +13,11 @@ content:
     start_path: home
     branches: HEAD
   - url: https://github.com/hazelcast/imdg-docs
-    branches: [master, v*]
+    branches: [master]
+    tags: [v*, "!v4.0*" , "!v3.12", "!v3.12.1", "!v3.12.2", "!v3.12.3",
+    "!v3.12.4", "!v3.12.5*", "!v3.12.6", "!v3.12.7", "!v3.12.8", "!v3.12.9",
+    "!v3.12.11", "!v3.11*", "!v3.10*", "!v3.9*", "!v3.8*", "!v3.7*", "!v3.6*",
+    "!v3.5*", "!v3.4*", "!v3.3*", "!v*-BETA*"]
     start_path: docs
   - url: https://github.com/hazelcast/imdg-docs
     branches: [archive]
@@ -26,7 +30,7 @@ content:
     start_paths: docs/*
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.4.5/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.4.6/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "ISC",
   "scripts": {
     "build": "antora --to-dir docs --fetch --generator @antora/site-generator-default antora-playbook.yml && cp _redirects docs",
-    "build-local": "antora --to-dir docs --fetch --generator @antora/site-generator-default antora-playbook-local.yml && cp _redirects docs",
+    "build-local": "antora --to-dir docs --fetch --generator @antora/site-generator-default antora-playbook-local.yml",
     "check-links": "antora --generator @antora/xref-validator antora-playbook.yml",
     "check-links-local": "antora --generator @antora/xref-validator antora-playbook-local.yml",
     "serve": "serve docs",


### PR DESCRIPTION
# Description of change

To avoid having lots of redundant branches in content repositories and to make automated releasing easier, we decided to pull content from tags.

This PR includes the configuration for pulling from tags with a `v` prefix as well as ignoring old tags by using the negated glob patterns (`!`).

This PR also updates the [UI bundle with a patch fix for duplicated versions in the version selector](https://github.com/hazelcast/hazelcast-docs-ui/releases/tag/v1.4.6).

## Type of change

Select the type of change you're making by adding an X to the box:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.