### PR TITLE
Configure search to display the section title next to the page title

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -31,7 +31,7 @@ content:
     start_paths: docs/*
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.4.6/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.5.1/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -31,7 +31,7 @@ content:
     start_paths: docs/*
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.4.6/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v1.5.1/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/search-config.json
+++ b/search-config.json
@@ -34,8 +34,13 @@
         "global": true,
         "default_value": "Hazelcast IMDG"
       },
-      "lvl1": ".doc h1",
-      "lvl2": ".doc h2",
+      "lvl1": {
+          "selector": "/html[1]/body[1]/div[1]/main[1]/div[1]/nav[1]/ul[1]/li[2]/a[1]",
+          "type": "xpath",
+          "global": true
+      },
+      "lvl2": ".doc h1",
+      "lvl3": ".doc h2",
       "text": ".doc p, .doc td.content, .doc th.tableblock"
     },
     "mc": {
@@ -45,8 +50,13 @@
         "global": true,
         "default_value": "Hazelcast Management Center"
       },
-      "lvl1": ".doc h1",
-      "lvl2": ".doc h2",
+      "lvl1": {
+        "selector": "/html[1]/body[1]/div[1]/main[1]/div[1]/nav[1]/ul[1]/li[2]/a[1]",
+        "type": "xpath",
+        "global": true
+      },
+      "lvl2": ".doc h1",
+      "lvl3": ".doc h2",
       "text": ".doc p, .doc td.content, .doc th.tableblock"
     }
   }


### PR DESCRIPTION
# Description of change

The search was duplicating the page title in results. To fix this, we are now selecting the section name using an xpath.

This PR also updates the UI to version [1.5.1](https://github.com/hazelcast/hazelcast-docs-ui/releases/tag/v1.5.1).

## Type of change

Select the type of change you're making by adding an X to the box:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.