### PR TITLE
Test a fix for missing search indices

### DIFF
--- a/search-config.json
+++ b/search-config.json
@@ -4,14 +4,14 @@
     {
       "url": "https://docs.hazelcast.com/imdg/(?P<version>.*?)/",
       "variables": {
-        "version": ["latest"]
+        "version": ["4.1.2"]
       },
       "selectors_key": "imdg"
     },
     {
       "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
       "variables": {
-        "version": ["latest"]
+        "version": ["4.2021.03"]
       },
       "selectors_key": "mc"
     }


### PR DESCRIPTION
# Description of change

Since 16 March we only have 59 search records instead of ~11k.

This seems to coincide with the update to IMDG version 4.1.2.

This is a test to see if explicity using version numbers instead of the `latest` alias makes a difference.

## Type of change

Select the type of change you're making by adding an X to the box:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.