### PR TITLE
Fix redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,14 +1,18 @@
 # Redirect latest imdg alias to the latest version
 /imdg/latest/*  /imdg/4.2/:splat 200!
+/imdg/latest  /imdg/4.2/index.html 200!
 
 # Redirect latest management-center alias to the latest version
 /management-center/latest/*  /management-center/4.2021.04/:splat 200!
+/management-center/latest  /management-center/4.2021.04/index.html 200!
 
 # Redirect latest-dev imdg alias to the latest-dev version
 /imdg/latest-dev/*  /imdg/5.0-snapshot/:splat 200!
+/imdg/latest-dev  /imdg/5.0-snapshot/index.html 200!
 
 # Redirect latest-dev management-center alias to the latest version
 /management-center/latest-dev/*  /management-center/4.2021.06-snapshot/:splat 200!
+/management-center/latest-dev  /management-center/4.2021.06-snapshot/index.html 200!
 
 # Redirect older 4.1.x versions to 4.1
 /imdg/4.1.1/*  /imdg/4.1/:splat 200!

--- a/search-config.json
+++ b/search-config.json
@@ -17,7 +17,7 @@
         "management-center"
       ],
       "variables": {
-        "version": ["4.2021.03"]
+        "version": ["4.2021.04"]
       },
       "selectors_key": "mc"
     },


### PR DESCRIPTION
# Description of change

- Redirected URLs that go to `/latest` to the index page to fix an issue where clicking links in the side nav results in a 404.
- Changed the indexer configuration to index the new latest version of Management Center.

## Type of change

Select the type of change you're making by adding an X to the box:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.