### PR TITLE
Configure indexer for Turbine docs

### DIFF
--- a/.github/workflows/index-turbine.yml
+++ b/.github/workflows/index-turbine.yml
@@ -1,0 +1,22 @@
+# This workflow runs a web scraper
+# that indexes the prototype documentation site for Hazelcast Turbine
+# and uploads that index to Algolia at the end of every day.
+
+name: Index Turbine
+
+on:
+  schedule:
+    - cron: "0 0 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env: 
+      APPLICATION_ID: ${{ secrets.ALGOLIA_APP_ID }}
+      API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        docker run -e APPLICATION_ID=$APPLICATION_ID -e API_KEY=$API_KEY -e "CONFIG=$(cat search-config-turbine.json | jq -r tostring)" algolia/docsearch-scraper

--- a/search-config-turbine.json
+++ b/search-config-turbine.json
@@ -1,0 +1,50 @@
+{
+  "index_name": "test_turbine",
+  "start_urls": [
+    {
+      "url": "https://focused-mclean-e58246.netlify.app/turbine/(?P<version>.*?)/",
+      "tags": [
+        "turbine"
+      ],
+      "variables": {
+        "version": ["0.1"]
+      },
+      "selectors_key": "turbine"
+    }
+  ],
+  "sitemap_urls": [
+    "https://focused-mclean-e58246.netlify.app/sitemap.xml"
+  ],
+  "stop_urls": [
+    "index.html"
+  ],
+  "selectors": {
+    "default": {
+      "lvl0": ".doc h1",
+      "lvl1": ".doc h2",
+      "text": ".doc p, .doc td.content, .doc th.tableblock"
+    },
+    "turbine": {
+      "lvl0": {
+        "selector": "/html[1]/body[1]/div[1]/main[1]/div[1]/nav[1]/ul[1]/li[1]/a[1]",
+        "type": "xpath",
+        "global": true,
+        "default_value": "Turbine"
+      },
+      "lvl1": {
+          "selector": "/html[1]/body[1]/div[1]/main[1]/div[1]/nav[1]/ul[1]/li[3]",
+          "type": "xpath",
+          "global": true
+      },
+      "lvl2": ".doc h1",
+      "lvl3": ".doc h2",
+      "lvl4": ".doc h3",
+      "text": ".doc p, .doc td.content, .doc th.tableblock"
+    }
+  },
+  "custom_settings": {
+    "attributesForFaceting": [
+      "tags"
+    ]
+  }
+}


### PR DESCRIPTION
# Description of change

We now have a prototype documentation site for Turbine: https://github.com/hazelcast/turbine/pull/123.

This PR adds a scheduled indexer to allow us to search that site.

## Type of change

Select the type of change you're making by adding an X to the box:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.