### PR TITLE
DOCS-111 Index other versions of content

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -32,7 +32,7 @@ content:
     start_path: docs
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v2.1/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v2.2/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -32,7 +32,7 @@ content:
     start_path: docs
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v2.2/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v2.2-DRAFT/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -32,7 +32,7 @@ content:
     start_path: docs
 ui: 
   bundle:
-    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v2.1/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/download/v2.2/ui-bundle.zip
     snapshot: true
 asciidoc:
   attributes:

--- a/search-config.json
+++ b/search-config.json
@@ -4,12 +4,52 @@
     {
       "url": "https://docs.hazelcast.com/imdg/(?P<version>.*?)/",
       "tags": [
-        "imdg"
+        "imdg-4.2"
       ],
       "variables": {
         "version": ["4.2"]
       },
       "selectors_key": "imdg"
+    },
+    {
+      "url": "https://docs.hazelcast.com/imdg/(?P<version>.*?)/",
+      "tags": [
+        "imdg-4.1"
+      ],
+      "variables": {
+        "version": ["4.1"]
+      },
+      "selectors_key": "imdg"
+    },
+    {
+      "url": "https://docs.hazelcast.com/imdg/(?P<version>.*?)/",
+      "tags": [
+        "imdg-3.12"
+      ],
+      "variables": {
+        "version": ["3.12"]
+      },
+      "selectors_key": "imdg"
+    },
+    {
+      "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
+      "tags": [
+        "management-center"
+      ],
+      "variables": {
+        "version": ["5.0-snapshot"]
+      },
+      "selectors_key": "mc"
+    },
+    {
+      "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
+      "tags": [
+        "management-center"
+      ],
+      "variables": {
+        "version": ["5.0-beta-1"]
+      },
+      "selectors_key": "mc"
     },
     {
       "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
@@ -20,6 +60,56 @@
         "version": ["4.2021.06"]
       },
       "selectors_key": "mc"
+    },
+    {
+      "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
+      "tags": [
+        "management-center"
+      ],
+      "variables": {
+        "version": ["4.2021.04"]
+      },
+      "selectors_key": "mc"
+    },
+    {
+      "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
+      "tags": [
+        "management-center"
+      ],
+      "variables": {
+        "version": ["4.2021.03"]
+      },
+      "selectors_key": "mc"
+    },
+    {
+      "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
+      "tags": [
+        "management-center"
+      ],
+      "variables": {
+        "version": ["4.2021.02"]
+      },
+      "selectors_key": "mc"
+    },
+    {
+      "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
+      "tags": [
+        "management-center"
+      ],
+      "variables": {
+        "version": ["4.2020.12"]
+      },
+      "selectors_key": "mc"
+    },
+    {
+      "url": "https://docs.hazelcast.com/hazelcast/(?P<version>.*?)/",
+      "tags": [
+        "hazelcast"
+      ],
+      "variables": {
+        "version": ["5.0-snapshot"]
+      },
+      "selectors_key": "hz"
     },
     {
       "url": "https://docs.hazelcast.com/hazelcast/(?P<version>.*?)/",

--- a/search-config.json
+++ b/search-config.json
@@ -1,5 +1,5 @@
 {
-  "index_name": "prod_hazelcast_docs",
+  "index_name": "test_hazelcast_docs",
   "start_urls": [
     {
       "url": "https://docs.hazelcast.com/imdg/(?P<version>.*?)/",


### PR DESCRIPTION
# Description of change

Updated the indexer to index not only the latest version of content but any previous versions that are hosted on docs.hazelcast.com.

When searching through all products, the new UI also filters the input to search only the latest compatible product versions where necessary .

## Type of change

Select the type of change you're making by adding an X to the box:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [x] Update Algolia subscription
- [x] Release version 2.2 of UI