### PR TITLE
Redirect /hazelcast to the docs home page

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -7,6 +7,9 @@
 # Redirect latest hazelcast alias to the latest version
 /hazelcast/latest/*  /hazelcast/5.0/:splat 200!
 
+# Redirect /hazelcast to home page
+/hazelcast/  /home/:splat 200!
+
 # Redirect latest-dev imdg alias to the latest-dev version
 /imdg/latest-dev/*  /hazelcast/5.1-snapshot/:splat 200!
 


### PR DESCRIPTION
# Description of change

We seem to get lots of 404s reported due to users searching for docs.hazelcast.com/hazelcast.

This PR redirects this path to the docs home page.

## Type of change

Select the type of change you're making by adding an X to the box:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.