### PR TITLE
Drop the html extension from URLs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -7,6 +7,8 @@ site:
     docsearch_id: 'QK2EAH8GB0'
     docsearch_api: 'ef7bd9485eafbd75d6e8425949eda1f5'
     docsearch_index: 'prod_hazelcast_docs'
+urls:
+  html_extension_style: drop
 content:
   sources: 
   - url: .


### PR DESCRIPTION
# Description of change

We use Netlify pretty URLs, which drops all HTML file extensions from URLs on the site. But the sitemap is still referring to URLs with the HTML file extension, which can lead to SEO issues.

This PR drops the HTML file extension from the URLs in the sitemap: https://docs.antora.org/antora/2.3/playbook/urls-html-extension-style/

## Type of change

Select the type of change you're making by adding an X to the box:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.