### PR TITLE
Upgrade Antora to 3.0.0-beta.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /docs/
 /build/
 .DS_Store
+package-lock.json

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -24,8 +24,8 @@ content:
   - url: https://github.com/hazelcast/management-center-docs
     branches: [main, v/*]
     start_path: docs
-  - url: https://github.com/hazelcast/management-center-docs #../mc-docs
-    branches: [archived-versions] #branches: HEAD
+  - url: https://github.com/hazelcast/management-center-docs
+    branches: [archived-versions]
     start_paths: docs/*
   - url: https://github.com/hazelcast/cloud-docs
     branches: [main]
@@ -34,6 +34,40 @@ ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip
     snapshot: true
+runtime:
+  log:
+    level: debug
+antora:
+  extensions:
+    - require: "./extension/lib/index.js"
+      trace: true
+      enabled: false
+      componentversions:
+        - name: management-center
+          version: '5.1-snapshot'
+          mappings:
+            - module: ROOT
+              family: attachment
+              origin:
+                url:
+                  include:
+                    - '**/JakeSCahill/management-center'
+                branch:
+                  includes:
+                    - 'master'
+
+        - name: management-center
+          version: '5.0'
+          mappings:
+            - module: ROOT
+              family: attachment
+              origin:
+                url:
+                  include:
+                    - '**/JakeSCahill/management-center'
+                branch:
+                  includes:
+                    - 'v/5.0'
 asciidoc:
   attributes:
     page-pagination: true
@@ -47,8 +81,6 @@ asciidoc:
     imdg-ops-guide: https://hazelcast.com/resources/hazelcast-deployment-operations-guide/
     jet-docs: https://jet-start.sh/
     docs-archive: 'https://hazelcast.org/imdg/download/archives/'
-    distribution-link-windows: 'https://download.hazelcast.com/download.jsp?version=hazelcast-5.0-BETA-1&p='
-    distribution-link-mac-linux: 'https://download.hazelcast.com/download.jsp?version=hazelcast-5.0-BETA-1&type=tar&p='
-    distribution-link-ee: https://download.hazelcast.com/enterprise/hazelcast-enterprise-5.0-BETA-1.zip
   extensions:
     - ./lib/tabs-block.js
+    - ./lib/swagger-ui-block-macro.js

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -68,7 +68,7 @@ antora:
                     - 'v/5.0'
 asciidoc:
   attributes:
-    page-pagination: true
+    page-pagination: true@
     idprefix: ''
     idseparator: '-'
     page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -36,9 +36,39 @@ ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip
     snapshot: true
+antora:
+  extensions:
+    - require: "./extension/lib/index.js"
+      trace: true
+      componentversions:
+        - name: management-center
+          version: '5.1-snapshot'
+          mappings:
+            - module: ROOT
+              family: attachment
+              origin:
+                url:
+                  include:
+                    - '**/JakeSCahill/management-center'
+                branch:
+                  includes:
+                    - 'master'
+
+        - name: management-center
+          version: '5.0'
+          mappings:
+            - module: ROOT
+              family: attachment
+              origin:
+                url:
+                  include:
+                    - '**/JakeSCahill/management-center'
+                branch:
+                  includes:
+                    - 'v/5.0'
 asciidoc:
   attributes:
-    page-pagination: true@
+    page-pagination: true
     idprefix: ''
     idseparator: '-'
     page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
@@ -47,11 +77,8 @@ asciidoc:
     imdg-core: https://github.com/hazelcast/hazelcast/tree/master/hazelcast/src/main/java/com/hazelcast
     imdg-docs: https://docs.hazelcast.org/docs/latest/manual/html-single/index.html
     imdg-ops-guide: https://hazelcast.com/resources/hazelcast-deployment-operations-guide/
-    mc-docs: https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html
     jet-docs: https://jet-start.sh/
     docs-archive: 'https://hazelcast.org/imdg/download/archives/'
-    distribution-link-windows: 'https://download.hazelcast.com/download.jsp?version=hazelcast-5.0-BETA-1&p='
-    distribution-link-mac-linux: 'https://download.hazelcast.com/download.jsp?version=hazelcast-5.0-BETA-1&type=tar&p='
-    distribution-link-ee: https://download.hazelcast.com/enterprise/hazelcast-enterprise-5.0-BETA-1.zip
   extensions:
     - ./lib/tabs-block.js
+    - ./lib/swagger-ui-block-macro.js

--- a/extension/.eslintrc
+++ b/extension/.eslintrc
@@ -1,0 +1,19 @@
+{
+  "extends": "standard",
+  "rules": {
+    "arrow-parens": ["error", "always"],
+    "comma-dangle": ["error", {
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "always-multiline",
+      "exports": "always-multiline"
+    }],
+    "max-len": ["error", {
+      "code": 120,
+      "ignoreStrings": true,
+      "ignoreUrls": true,
+      "ignoreTemplateLiterals": true
+    }],
+    "spaced-comment": "off"
+  }
+}

--- a/extension/README.adoc
+++ b/extension/README.adoc
@@ -1,0 +1,95 @@
+= Antora aggregate collector pipeline extension
+
+This Antora pipeline extension includes content in a component-version that is not in the Antora file system layout.
+The content to be included must be in a listed source, under a start path with an `antora.yml` component descriptor.
+
+== Configuration
+
+Most configuration is done in a `componentversions` key in the Antora playbook:
+
+[source,yaml]
+----
+antora:
+  extensions:
+    - require: "@whoindeed/antora-aggregate-collector"
+      trace: true
+      componentversions:
+        - name: components
+          version: latest
+          mappings:
+            - module: ROOT
+              family: page
+              origin:
+                url:
+                  includes:
+                    - '**/*component'
+              path:
+                includes:
+                  - '*/**/README.adoc'
+              relativemap:
+                - match: '(?<project>*)/src/main/docs/README.adoc'
+                  format: 'projects/${project}.adoc'
+----
+
+The `mappings` key contains a list of mapping elements, which are applied in order.
+Once there is a match, no further mappings are considered.
+
+=== Matching
+
+All matching is done with https://github.com/micromatch/picomatch#picomatch[picomatch].
+The filtering keys allow you to specify lists of include and exclude globs.
+The `relativemap.match` allows only a single glob with named groups.
+
+=== Selecting content to be included
+
+`componentversions` key::
+Specify single include patterns for component name and version to be scanned.
+
+`origin.url` key::
+This filters the url (`file.src.origin.url`) of sources of files in the content aggregate.
+
+`origin.branch` key::
+This filters the branch (`file.src.origin.branch`) of sources of files in the content aggregate.
+Either branch or tag can match.
+
+`origin.tag` key::
+This filters the tag (`file.src.origin.tag`) of sources of files in the content aggregate.
+Either branch or tag can match.
+
+`origin.startPath` key::
+This filters the start_path (`file.src.origin.startPath`) of sources of files in the content aggregate.
+
+`path` key::
+This filters the path (`file.src.path`) of files in the content aggregate.
+
+=== Mapping the location of selected files
+
+The module and family of the mapped target location are specified directly in the mapping configuration.
+By default, the file path (from the start path) is used as the relative segment of the target.
+You may also specify a list of `relativemap` mappings.
+At most one `relativemap` mapping is applied to any file.
+
+`match`::
+A single picomatch glob expression with named capture groups.
+A named capture group is of the form `(?<name>pattern)` just as in a javascript regular expression named capture group.
+
+`format`::
+A simple format string containing literals and expressions of the form `${name}` where `name` is the name of a capture group in the match expression.
+The relative segment of the file is set to the evaluation of the format string using the named values extracted from the original path.
+
+For example, suppose you have a maven multi-module project with the `antora.yml` file in the root of the project, and per-project `README.adoc` files in a maven-appropriate location `src/main/docs/` in each project.
+The sample relativemap above will relocate these `README.adoc` files in the Antora content aggregate to appear in an Antora appropriate location of `modules/components/pages/projects/<project-name>.adoc`.
+
+== Log configuration
+
+Setting the `trace` key will cause the extension to log aggregated files at debug level, something like this:
+
+----
+[16:30:43.743] DEBUG (antora-aggregate-collector): mapped file to modules/project/pages/projects/project.adoc
+    component: "java-project"
+    version: "2.6"
+    file: /Users/david/projects/antora/extensions/antora-aggregate-collector/example/java-project/project/src/main/docs/README.adoc
+    source: /Users/david/projects/antora/extensions/antora-aggregate-collector (refname: rwinch-copy1 <worktree>, start path: example/java-project)
+----
+
+Note that you have to set the `runtime.log.level` key to `debug` to see debug level logging.

--- a/extension/lib/include.js
+++ b/extension/lib/include.js
@@ -1,0 +1,101 @@
+'use strict'
+
+const picomatch = require('picomatch')
+
+module.exports.register = (context, { config }) => {
+  const cvMappings = processConfig(config)
+  const trace = config.trace
+  const logger = context.require('@antora/logger')('antora-aggregate-collector')
+
+
+  context.on('contentAggregated', ({ contentAggregate }) => {
+    contentAggregate.forEach(({ name, version, files }) => {
+      cvMappings.forEach(({ nameMatch, versionMatch, mappings }) => {
+        if (nameMatch(name) && versionMatch(version)) {
+          files.forEach((f) => {
+            mappings.forEach(({
+              module, family,
+              urlMatch, startPathMatch, branchTagMatch,
+              pathMatch,
+              relativeMaps,
+            }) => {
+              if (urlMatch(f.src.origin.url) &&
+                    startPathMatch(f.src.origin.startPath) &&
+                    branchTagMatch(f.src.origin) &&
+                    pathMatch(f.src.path)) {
+                mapRelative(f, relativeMaps)
+                f.path = `modules/${module}/${family}s/${f.path}`
+                trace && logger.debug({ file: f.src, component: name, version }, `mapped file to ${f.path}`)
+              }
+            })
+          })
+        }
+      })
+    }
+    )
+  })
+}
+
+const GROUP_RX = /{([^}]+)}/g
+
+function expr (format) {
+  return (ctx) => format.replace(GROUP_RX, (_, name) => ctx[name])
+}
+
+function mapRelative (f, relativeMaps) {
+  relativeMaps.forEach(({ match, format }) => {
+    const m = match(f.path, true)
+    if (m.isMatch) {
+      const ctx = m.match.groups
+      f.path = format(ctx)
+    }
+  })
+}
+
+function picomatcher ({ include, exclude }) {
+  const options = exclude ? { ignore: exclude } : {}
+  return picomatch(include, options)
+}
+
+const TRUE = () => true
+
+function processConfig (config) {
+  const mappings = config.componentversions.map(({ name, version, mappings }) => {
+    return {
+      nameMatch: name ? picomatch(name) : TRUE,
+      versionMatch: version ? picomatch(version) : TRUE,
+      mappings: mappings.map(({ module, family, path, origin, relativemap }) => {
+        const { url, startPath, branch, tag } = (origin || {})
+        return {
+          module,
+          family,
+          pathMatch: (path && path.include) ? picomatcher(path) : TRUE,
+          urlMatch: (url && url.include) ? picomatcher(url) : TRUE,
+          startPathMatch: (startPath && startPath.include) ? picomatcher(startPath) : TRUE,
+          branchTagMatch: branchTagMatcher(branch, tag),
+          relativeMaps: relativemap ? relativemap.map(({ match, format }) => {
+            return { match: picomatch(match), format: expr(format) }
+          }) : [],
+        }
+      }),
+    }
+  })
+  return mappings
+  function branchTagMatcher (branch, tag) {
+    const branchMatch = (branch && branch.include) ? picomatch(branch) : false
+    const tagMatch = (tag && tag.include) ? picomatch(tag) : false
+    if (branchMatch) {
+      if (tagMatch) {
+        return (origin) => branchMatch(origin.branch) || tagMatch(origin.tag)
+      }
+      return (origin) => branchMatch(origin.branch)
+    } else if (tagMatch) {
+      return (origin) => tagMatch(origin.tag)
+    }
+    return TRUE
+  }
+}
+
+module.exports.expr = expr
+module.exports.mapRelative = mapRelative
+module.exports.processConfig = processConfig

--- a/extension/lib/index.js
+++ b/extension/lib/index.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports.register = require('./include').register

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@whoindeed/antora-aggregate-collector",
+  "version": "0.0.1",
+  "description": "Antora support for mapping files into expected Antora directory structure",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Rob Winch",
+      "email": "?"
+    },
+    {
+      "name": "David Jencks",
+      "email": "djencks@apache.org"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://gitlab.com/djencks/antora-aggregate-collector.git"
+  },
+  "main": "lib/index.js",
+  "files": [
+    "lib/*.js"
+  ],
+  "scripts": {
+    "clean-install": "rm -rf node_modules/ ;npm i --cache=.cache/npm",
+    "test": "mocha",
+    "lint": "eslint lib/**/**.js test/**/**.js",
+    "lint-fix": "eslint lib/**/**.js test/**/**.js --fix"
+  },
+  "dependencies": {
+    "picomatch": "^2.3.0"
+  },
+  "devDependencies": {
+    "chai": "~4.2",
+    "eslint": "~6.7",
+    "eslint-config-standard": "~14.1",
+    "eslint-plugin-import": "~2.19",
+    "eslint-plugin-node": "~10.0",
+    "eslint-plugin-promise": "~4.2",
+    "eslint-plugin-standard": "~4.0",
+    "mocha": "~6.2",
+    "prettier-eslint-cli": "~5.0"
+  }
+}

--- a/extension/test/test.js
+++ b/extension/test/test.js
@@ -1,0 +1,90 @@
+/* eslint-env mocha */
+'use strict'
+
+const picomatch = require('picomatch')
+const { expect } = require('chai')
+const { expr, mapRelative, processConfig } = require('./../lib/include')
+
+describe('how does picomatch work', () => {
+  it('true 2nd arg', () => {
+    const matcher = picomatch('a/(?<b>*)/c/(?<d>*)/(?<f>*).adoc')
+    const result1 = matcher('a/b/c/d/d.adoc')
+    const result2 = matcher('a/b/c/d/d.adoc', true)
+    expect(result1).to.equal(true)
+    expect(result2.isMatch).to.equal(true)
+    expect(result2.match.groups).to.deep.equal({ b: 'b', d: 'd', f: 'd' })
+  })
+})
+
+describe('expr test', () => {
+  it('basic', () => {
+    const result = expr('a/{b}/c/{d}/{e}.adoc')
+    expect(result({ b: 'bee', d: 'dee', e: 'eeeeee' })).to.equal('a/bee/c/dee/eeeeee.adoc')
+  })
+})
+
+const config = {
+  componentversions: [
+    {
+      name: 'foo',
+      version: 'next',
+      mappings: [
+        {
+          module: 'ROOT',
+          family: 'page',
+          path: {
+            includes: ['**/*'],
+          },
+          relativemap: [
+            {
+              match: 'a/(?<b>*)/c/(?<d>*)/README.adoc',
+              format: '{b}/{d}.adoc',
+            },
+          ],
+        },
+        {
+          module: 'project',
+          family: 'page',
+          path: {
+            includes: ['*/**/README.adoc'],
+          },
+          relativemap: [
+            {
+              match: '(?<project>*)/src/main/docs/README.adoc',
+              format: 'projects/{project}.adoc',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+describe('processConfig test', () => {
+  it('relative maps', () => {
+    const mapped = processConfig(config)
+    expect(mapped.length).to.equal(1)
+    expect(mapped[0].nameMatch('foo')).to.equal(true)
+    expect(mapped[0].nameMatch('bar')).to.equal(false)
+    expect(mapped[0].versionMatch('next')).to.equal(true)
+    expect(mapped[0].versionMatch('foo')).to.equal(false)
+    expect(mapped[0].mappings[0].relativeMaps.length).to.equal(1)
+    expect(mapped[0].mappings[0].relativeMaps[0].format({ b: 'x', d: 'y' })).to.equal('x/y.adoc')
+  })
+})
+
+describe('mapRelative test', () => {
+  it('mapRelative1', () => {
+    const relativeMaps = processConfig(config)[0].mappings[0].relativeMaps
+    const f = { path: 'a/foo/c/bar/README.adoc' }
+    mapRelative(f, relativeMaps)
+    expect(f.path).to.equal('foo/bar.adoc')
+  })
+
+  it('mapRelative2', () => {
+    const relativeMaps = processConfig(config)[0].mappings[1].relativeMaps
+    const f = { path: 'project/src/main/docs/README.adoc' }
+    mapRelative(f, relativeMaps)
+    expect(f.path).to.equal('projects/project.adoc')
+  })
+})

--- a/lib/swagger-ui-block-macro.js
+++ b/lib/swagger-ui-block-macro.js
@@ -1,0 +1,45 @@
+const buildSwaggerUi = ({ specUrl, bundleUrl }) => `<link rel="stylesheet" href="${bundleUrl}/swagger-ui.css">
+<script src="${bundleUrl}/swagger-ui-bundle.js"></script>
+<script src="${bundleUrl}/swagger-ui-standalone-preset.js"></script>
+<script id="swagger-ui-script" data-url="${specUrl}">
+;(function (config) {
+  function HideTopbarPlugin() {
+    // this plugin overrides the Topbar component to return nothing
+    return {
+      components: {
+        Topbar: function() { return null }
+      }
+    }
+  }
+  SwaggerUIBundle({
+    url: config.url,
+    dom_id: '#swagger-ui',
+    deepLinking: true,
+    presets: [SwaggerUIBundle.presets.apis, SwaggerUIStandalonePreset],
+    plugins: [SwaggerUIBundle.plugins.DownloadUrl,HideTopbarPlugin],
+    layout: 'StandaloneLayout',
+    tagsSorter: 'alpha',
+    operationsSorter: 'alpha',
+    docExpansion: 'none',
+  })
+})(document.getElementById('swagger-ui-script').dataset)
+</script>`
+
+function blockSwaggerUiMacro ({ file }) {
+  return function () {
+    this.process((parent, specUrl, attrs) => {
+      const doc = parent.getDocument()
+      specUrl = `${specUrl}`
+      const bundleUrl = 'https://unpkg.com/swagger-ui-dist@3.52.5'
+      const contentScripts = buildSwaggerUi({ specUrl, bundleUrl })
+      file.asciidoc.attributes['page-content-scripts'] = contentScripts
+      return this.createBlock(parent, 'pass', '<div id="swagger-ui"></div>')
+    })
+  }
+}
+
+function register (registry, context) {
+  registry.blockMacro('swagger_ui', blockSwaggerUiMacro(context))
+}
+
+module.exports.register = register

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "expose": "ngrok http 5000"
   },
   "devDependencies": {
-    "@antora/cli": "^2.3.4",
-    "@antora/site-generator-default": "^2.3.4",
+    "@antora/cli": "^3.0.0-beta.3",
+    "@antora/site-generator-default": "^3.0.0-beta.3",
     "@antora/xref-validator": "gitlab:antora/xref-validator",
-    "ngrok": "^3.3.0",
-    "serve": "^11.3.2"
+    "asciidoctor-kroki": "^0.10.0",
+    "ngrok": "^4.2.2",
+    "serve": "^13.0.2"
   }
 }


### PR DESCRIPTION
# Description of change

[Antora 3.0.0](https://docs.antora.org/antora/3.0/whats-new/) is about to be released, which comes with new features that we want to leverage in our docs.

The most important feature is [Antora extensions](https://docs.antora.org/antora/3.0/extend/extensions/). We can use this feature to pull code into the docs from any GH repository as long as it contains an `antora.yml` file.

This is the beta release. We will update to the GA release when it becomes available.

## Type of change

Select the type of change you're making by adding an X to the box:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.