### PR TITLE
Add Swagger UI support for Management Center

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -21,8 +21,8 @@ content:
   - url: https://github.com/hazelcast/imdg-docs
     branches: [archived-versions]
     start_paths: docs/*
-  - url: ../management-center-docs
-    branches: HEAD
+  - url: https://github.com/hazelcast/management-center-docs
+    branches: [main, v/*]
     start_path: docs
   - url: https://github.com/hazelcast/management-center-docs
     branches: [archived-versions]

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -52,7 +52,7 @@ antora:
       trace: true
       componentversions:
         - name: management-center
-          version: '5.1-snapshot'
+          version: '5.2-snapshot'
           mappings:
             - module: integrate
               family: attachment

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -51,7 +51,7 @@ antora:
       trace: true
       componentversions:
         - name: management-center
-          version: '5.1-snapshot'
+          version: '5.2-snapshot'
           mappings:
             - module: integrate
               family: attachment

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -63,17 +63,17 @@ antora:
                   includes:
                     - 'master'
         - name: management-center
-            version: '5.1'
-            mappings:
-              - module: integrate
-                family: attachment
-                origin:
-                  url:
-                    include:
-                      - '**/hazelcast/management-center'
-                  branch:
-                    includes:
-                      - '5.1'
+          version: '5.1'
+          mappings:
+            - module: integrate
+              family: attachment
+              origin:
+                url:
+                  include:
+                    - '**/hazelcast/management-center'
+                branch:
+                  includes:
+                    - '5.1'
 asciidoc:
   attributes:
     page-pagination: true@


### PR DESCRIPTION
# Description of change

This PR allows us to display the generated Swagger UI output for the external Management Center REST API endpoints.

## How it works

The Antora site generator has access only to files where the [`start_path`](https://docs.antora.org/antora/latest/playbook/content-source-start-path/) in a [playbook](https://docs.antora.org/antora/latest/playbook/) contains an `antora.yml` file. So we give Antora a `start_path` that points to a directory in the `management-center` repository, which contains the OpenAPI spec files. https://github.com/hazelcast/hazelcast-docs/blob/b8022580d91591642268e480a845c94cfb9ba6fa/antora-playbook.yml#L43 Then, we add an `antora.yml` file to that directory. This file must contain the name of the docs component in which the content will be available (`management-center`) as well as the version of the content.

To allow us to use these OpenAPI spec files in the docs, Antora expects them to be in a [standard directory structure](https://docs.antora.org/antora/latest/standard-directories/). But we don't want to have to change the directory structure in the `management-center` repository. Instead, we use a [custom extension](https://docs.antora.org/antora/latest/extend/extensions/) to place the OpenAPI spec files into the [`attachment/` directory](https://docs.antora.org/antora/latest/page/attachments/) during the build process, which allows us to access them from within doc pages. 
https://github.com/hazelcast/hazelcast-docs/blob/b8022580d91591642268e480a845c94cfb9ba6fa/antora-playbook.yml#L48

Related PRs:

- [x] https://github.com/hazelcast/management-center/pull/5441 https://github.com/hazelcast/management-center/pull/5442 To allow Antora to pull in the external OpenAPI spec files from the Management Center repository.
- [x] https://github.com/hazelcast/hazelcast-docs-ui/pull/156 To add custom styles to the output
- [ ] https://github.com/hazelcast/management-center-docs/pull/157 To display the output in the Management Center docs

## Type of change

Select the type of change you're making by adding an X to the box:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] This change affects the release pipeline. I've added some extra steps to the [README docs](https://github.com/hazelcast/management-center-docs/pull/157/files#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124):  We should agree these changes with the MC team. https://hazelcast.atlassian.net/browse/MC-1410