### PR TITLE
DOCS-216 Add attribute for Hazelcast Cloud name

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -173,14 +173,10 @@ asciidoc:
     page-experimental: true
     idprefix: ''
     idseparator: '-'
-    page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
     imdg-javadoc: https://docs.hazelcast.org/docs/latest-dev/javadoc
     imdg-samples: https://github.com/hazelcast/hazelcast-code-samples
-    imdg-core: https://github.com/hazelcast/hazelcast/tree/master/hazelcast/src/main/java/com/hazelcast
-    imdg-docs: https://docs.hazelcast.org/docs/latest/manual/html-single/index.html
-    imdg-ops-guide: https://hazelcast.com/resources/hazelcast-deployment-operations-guide/
-    jet-docs: https://jet-start.sh/
-    docs-archive: 'https://hazelcast.org/imdg/download/archives/'
+    docs-archive: https://hazelcast.org/imdg/download/archives/
+    hazelcast-cloud: Hazelcast Viridian
   extensions:
     - ./lib/tabs-block.js
     - ./lib/swagger-ui-block-macro.js

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -173,14 +173,10 @@ asciidoc:
     page-experimental: true
     idprefix: ''
     idseparator: '-'
-    page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
     imdg-javadoc: https://docs.hazelcast.org/docs/latest-dev/javadoc
     imdg-samples: https://github.com/hazelcast/hazelcast-code-samples
-    imdg-core: https://github.com/hazelcast/hazelcast/tree/master/hazelcast/src/main/java/com/hazelcast
-    imdg-docs: https://docs.hazelcast.org/docs/latest/manual/html-single/index.html
-    imdg-ops-guide: https://hazelcast.com/resources/hazelcast-deployment-operations-guide/
-    jet-docs: https://jet-start.sh/
-    docs-archive: 'https://hazelcast.org/imdg/download/archives/'
+    docs-archive: https://hazelcast.org/imdg/download/archives/
+    hazelcast-cloud: Hazelcast Viridian
   extensions:
     - ./lib/tabs-block.js
     - ./lib/swagger-ui-block-macro.js

--- a/assembler-playbook-platform-5-0.yml
+++ b/assembler-playbook-platform-5-0.yml
@@ -17,15 +17,12 @@ asciidoc:
   attributes:
     # Download images from kroki at build time (does not work for inline images)
     kroki-fetch-diagram: true
-    # Inlude next and previous links on each page
-    page-pagination: true
     idprefix: ''
     # Separate anchor link names by dashes
     idseparator: '-'
-    # Variables used in the docs
-    page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
     # Filter out content that doesn't apply to PDF such as embedded scripts
     backend-pdf: true
+    hazelcast-cloud: Hazelcast Viridian
   extensions:
     - ./lib/tabs-block.js
     - ./lib/swagger-ui-block-macro.js

--- a/assembler-playbook-platform-5-1.yml
+++ b/assembler-playbook-platform-5-1.yml
@@ -17,15 +17,12 @@ asciidoc:
   attributes:
     # Download images from kroki at build time (does not work for inline images)
     kroki-fetch-diagram: true
-    # Inlude next and previous links on each page
-    page-pagination: true
     idprefix: ''
     # Separate anchor link names by dashes
     idseparator: '-'
-    # Variables used in the docs
-    page-survey: https://www.surveymonkey.co.uk/r/NYGJNF9
     # Filter out content that doesn't apply to PDF such as embedded scripts
     backend-pdf: true
+    hazelcast-cloud: Hazelcast Viridian
   extensions:
     - ./lib/tabs-block.js
     - ./lib/swagger-ui-block-macro.js


### PR DESCRIPTION
# Description of change

To avoid having to update product names in multiple places, this PR adds a new attribute to hold the name of the Hazelcast Cloud product. We can reference this attribute when referring to Hazelcast Cloud.

## Type of change

Select the type of change that you're making:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.
