### PR TITLE
Add external backup and restore tutorial to the website

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -127,6 +127,9 @@ content:
   - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-expose-externally
     branches: main
     start_path: docs
+  - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore
+    branches: master
+    start_path: docs
   - url: https://github.com/hazelcast/management-center
     branches: [master, 5.1.z]
     start_path: openapi/external

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -130,6 +130,9 @@ content:
   - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-expose-externally
     branches: main
     start_path: docs
+  - url: https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore
+    branches: master
+    start_path: docs
   - url: https://github.com/hazelcast/management-center
     branches: [master, 5.1.z]
     start_path: openapi/external


### PR DESCRIPTION
# Description of change

I have already created a [tutorial](https://github.com/hazelcast-guides/hazelcast-platform-operator-external-backup-restore) but I realize that I forgot to add it to the tutorial webpage. I updated the antora-playbook files.

## Type of change

Select the type of change that you're making:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.
