### PR TITLE
Index site twice per month

### DIFF
--- a/.github/workflows/index-site.yml
+++ b/.github/workflows/index-site.yml
@@ -5,7 +5,7 @@ name: Index site
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 1,15 * *"
   workflow_dispatch:
 
 jobs:

--- a/README.adoc
+++ b/README.adoc
@@ -178,7 +178,9 @@ To automate some elements of the build process, this repository includes the fol
 
 |index-site.yml
 |Runs the link:{url-github-docsearch-scraper}[DocSearch scraper] in a Docker container to index the site and send the index to Algolia
-|Once per day at 00:00 UTC
+|1st and 15th of every month at 00:00 UTC
+
+NOTE: We used to run this one per day but it was causing overage charges. The crawler that we use uploads a temporary index before deleting the old one. This causes us to go over our limit more than three days in a month, which is the grace period that Algolia provides.
 
 |publish-to-production.yml
 |Merges the `develop` branch into the `main` branch to publish changes on the staging site to production.


### PR DESCRIPTION
# Description of change

The crawler that we use uploads a temporary index before deleting the old one. This causes us to go over our limit more than three days in a month, which is the grace period that Algolia provides.

We now do an automated reindexing twice per month on the 1st and 15th.
## Type of change

Select the type of change that you're making:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.
