### PR TITLE
HZC-3699: extension for generate JSON summary page

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -196,6 +196,35 @@ antora:
                 branch:
                   includes:
                     - '5.1.z'
+    - require: ./lib/api_json.js
+      tags:
+        - Favorites
+        - Videos
+        - Get Started
+        - Whitepapers
+        - Use cases
+        - Case studies
+        - Documentation
+        - Develop Applications
+        - Manage Accounts
+        - Manage Clusters
+      data:
+        - title: What is Viridian Serverless?
+          url: https://www.youtube.com/embed/5bLjl-iqFaU'
+          type: video
+          order: 7
+          tags: Videos, Get Started
+        - title: What is client?
+          url: https://www.youtube.com/embed/lkQEAdgxvbE
+          type: video
+          order: 8
+          tags: Videos, Get Started
+        - title: What is the Hazelcast Platform?
+          url: https://www.youtube.com/embed/UpIgHzKbMp0
+          type: video
+          order: 9
+          tags: Videos, Get Started
+
 asciidoc:
   attributes:
     # Order the products in the version selector dropdown.

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -211,6 +211,35 @@ antora:
                 branch:
                   includes:
                     - '5.1.z'
+    - require: ./lib/api_json.js
+      tags:
+        - Favorites
+        - Videos
+        - Get Started
+        - Whitepapers
+        - Use cases
+        - Case studies
+        - Documentation
+        - Develop Applications
+        - Manage Accounts
+        - Manage Clusters
+      data:
+        - title: What is Viridian Serverless?
+          url: https://www.youtube.com/embed/5bLjl-iqFaU'
+          type: video
+          order: 7
+          tags: Videos, Get Started
+        - title: What is client?
+          url: https://www.youtube.com/embed/lkQEAdgxvbE
+          type: video
+          order: 8
+          tags: Videos, Get Started
+        - title: What is the Hazelcast Platform?
+          url: https://www.youtube.com/embed/UpIgHzKbMp0
+          type: video
+          order: 9
+          tags: Videos, Get Started
+
 asciidoc:
   attributes:
     # Order the products in the version selector dropdown.

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -170,6 +170,17 @@ ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip
     snapshot: true
+  supplemental_files:
+    - path: netlify.toml
+      contents: >
+        [[headers]]
+          for = "/api/*"
+          [headers.values]
+            Access-Control-Allow-Origin = "*"
+    - path: ui.yml
+      contents: |
+        static_files: [ netlify.toml ]
+
 antora:
   extensions:
     - require: '@djencks/antora-aggregate-collector'

--- a/lib/api_json.js
+++ b/lib/api_json.js
@@ -35,9 +35,10 @@ module.exports.register = function ({config}) {
                         const tags_multi = item.asciidoc.attributes['cloud-tags'].split('|')[index]
                         const order_multi = item.asciidoc.attributes['cloud-order'] ? item.asciidoc.attributes['cloud-order'].split('|')[index] : ''
                         const anchor_multi = item.asciidoc.attributes['cloud-anchor'] ? item.asciidoc.attributes['cloud-anchor'].split('|')[index] : ''
+                        const url_multi = item.asciidoc.attributes['cloud-url-video'] ? item.asciidoc.attributes['cloud-url-video'].split('|')[index] : item.pub.url
                         addEntity({
                             title: title_multi ?? item.title,
-                            url: url + (!!anchor_multi ? `#${anchor_multi.trim()}` : ''),
+                            url: url_multi + (!!anchor_multi ? `#${anchor_multi.trim()}` : ''),
                             tags: tags_multi,
                             type,
                             order: order_multi ?? 0

--- a/lib/api_json.js
+++ b/lib/api_json.js
@@ -2,24 +2,6 @@
 
 /**
  * Create a JSON file with a summary of the pages
- *
- * Usage:
- *
- *  [tabs]
- *  ====
- *  Tab A::
- *  +
- *  --
- *  Contents of tab A.
- *  --
- *  Tab B::
- *  +
- *  --
- *  Contents of tab B.
- *  --
- *  ====
- *
- * @author Dan Allen <dan@opendevise.com>
  */
 
 
@@ -27,7 +9,7 @@ module.exports.register = function ({config}) {
     let content = []
     const addEntity = ({title, url, tags, type, order}) => {
         const arr = tags.split(',').map(cat => cat.trim())
-        if (!arr.some(name => (config.tags ?? []).includes(name))) {
+        if (config.tags && !arr.some(name => (config.tags ?? []).includes(name))) {
             throw Error(`Wrong cloud tag '${name}'`)
         }
         content.push({

--- a/lib/api_json.js
+++ b/lib/api_json.js
@@ -1,0 +1,85 @@
+'use strict'
+
+/**
+ * Create a JSON file with a summary of the pages
+ *
+ * Usage:
+ *
+ *  [tabs]
+ *  ====
+ *  Tab A::
+ *  +
+ *  --
+ *  Contents of tab A.
+ *  --
+ *  Tab B::
+ *  +
+ *  --
+ *  Contents of tab B.
+ *  --
+ *  ====
+ *
+ * @author Dan Allen <dan@opendevise.com>
+ */
+
+
+module.exports.register = function ({config}) {
+    let content = []
+    const addEntity = ({title, url, tags, type, order}) => {
+        const arr = tags.split(',').map(cat => cat.trim())
+        if (!arr.some(name => (config.tags ?? []).includes(name))) {
+            throw Error(`Wrong cloud tag '${name}'`)
+        }
+        content.push({
+            title: title && title.trim(),
+            url: url && url.trim(),
+            tags: arr,
+            type: type && type.trim(),
+            order: order ? parseInt(order) : 0
+        })
+    }
+    (config.data ?? []).forEach(item => addEntity(item))
+    this.on('documentsConverted', ({contentCatalog}) => {
+        contentCatalog.findBy({family: 'page'}).forEach((item) => {
+            const urlVideo = item.asciidoc.attributes['cloud-url-video']
+            const type = urlVideo ? 'video' : 'article'
+            const url = urlVideo ?? item.pub.url
+            const tags = item.asciidoc.attributes['cloud-tags']
+            const title = item.asciidoc.attributes['cloud-title'] ?? item.title
+            const order = item.asciidoc.attributes['cloud-order']
+            if (tags) {
+                if (title.includes('|')) {
+                    title.split('|').forEach((title_multi, index) => {
+                        const tags_multi = item.asciidoc.attributes['cloud-tags'].split('|')[index]
+                        const order_multi = item.asciidoc.attributes['cloud-order'] ? item.asciidoc.attributes['cloud-order'].split('|')[index] : ''
+                        const anchor_multi = item.asciidoc.attributes['cloud-anchor'] ? item.asciidoc.attributes['cloud-anchor'].split('|')[index] : ''
+                        addEntity({
+                            title: title_multi ?? item.title,
+                            url: url + (!!anchor_multi ? `#${anchor_multi.trim()}` : ''),
+                            tags: tags_multi,
+                            type,
+                            order: order_multi ?? 0
+                        })
+                    })
+                } else {
+                    addEntity({
+                        title,
+                        url,
+                        tags,
+                        type,
+                        order
+                    })
+                }
+            }
+        })
+    })
+        .on('beforePublish', ({siteCatalog}) => {
+            siteCatalog.addFile({
+                contents: Buffer.from(JSON.stringify({
+                    tags: config.tags ?? [],
+                    links: content.sort((a, b) => a.order - b.order)
+                })),
+                out: {path: config.path ?? 'api/all.json'}
+            })
+        })
+}

--- a/lib/api_json.js
+++ b/lib/api_json.js
@@ -62,7 +62,7 @@ module.exports.register = function ({config}) {
                     tags: config.tags ?? [],
                     links: content.sort((a, b) => a.order - b.order)
                 })),
-                out: {path: config.path ?? 'api/all.json'}
+                out: {path: config.path ?? 'api/cloud.json'}
             })
         })
 }


### PR DESCRIPTION
# Description of change

This PR allows us to generate a summary for some pages in JSON format, which we can use as an API endpoint.

## How it works

To add any page to the summary we need to add the special tag:
```
:cloud-tags: Favorites
```
or multiple tags:
```
:cloud-tags: Favorites, Tops
```

or other manage tags:
```
:cloud-title: Custom Title
:cloud-order: 5
:cloud-anchor: section2
```

To add multiple items in a summary from one page `:cloud-title:` is required:

```
:cloud-title: Custom Title | Section 2 Title | Video Source
:cloud-tags: Favorites | Tops | Videos
:cloud-order: 5 | 8 | 10
:cloud-anchor: | section2 |
:cloud-url-video: || youtube 
```

### Configure extension

- to start validation for used tags we can add them to the list:

```
      tags:
        - Tag 1
        - Tag 2
```

- to add manually items in the summary:

```
      data:
        - title: Page One
          url: /cloud/page-1
          type: article
          order: 10
          tags: Favorites
        - title: Page Two
          url: https://www.youtube.com/embed/...
          type: video
          order: 12
          tags: Videos
```


## Type of change

Select the type of change that you're making:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.
