### PR TITLE
DOCS-376 Updates to CLC search and redirects config

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -16,6 +16,9 @@
 # Redirect latest-dev imdg alias to the latest-dev version
 /imdg/latest-dev/*  /hazelcast/5.3-snapshot/:splat 200!
 
+# Redirect latest-dev clc alias to the latest-dev version
+/clc/latest-dev/*  /clc/5.2.0-beta-3/:splat 200!
+
 # Redirect latest-dev management-center alias to the latest version
 /management-center/latest-dev/*  /management-center/5.3-snapshot/:splat 200!
 

--- a/search-config.json
+++ b/search-config.json
@@ -220,13 +220,13 @@
       "selectors_key": "cloud"
     },
     {
-      "url": "https://docs.hazelcast.com/hazelcast-commandline-client/(?P<version>.*?)/",
+      "url": "https://docs.hazelcast.com/clc/(?P<version>.*?)/",
       "tags": [
-        "hazelcast-commandline-client-5.2-beta-3"
+        "clc-5.2-beta-3"
       ],
       "variables": {
         "version": [
-          "5.2-beta-3"
+          "5.2.0-beta-3"
         ]
       },
       "selectors_key": "command-line-client"


### PR DESCRIPTION
# Description of change

CLC subsite is not being indexed for search and does not have a redirect set up.

Current URL: https://docs.hazelcast.com/clc/5.2.0-beta-3/overview

## Type of change

Select the type of change that you're making:

- [x ] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)
