### PR TITLE
DOCS-422_Add redirect for CLC

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -19,6 +19,9 @@
 # Redirect latest-dev clc alias to the latest-dev version
 /clc/latest-dev/*  /clc/5.2-beta-3/:splat 200!
 
+# Redirect renamed beta version to the currecnt beta version
+/clc/5.2.0-beta-3/* /clc/5.2-beta-3/:splat 200!
+
 # Redirect latest-dev management-center alias to the latest version
 /management-center/latest-dev/*  /management-center/5.3-snapshot/:splat 200!
 


### PR DESCRIPTION
# Description of change

The version no. of CLC was renamed for search purposes. This PR adds a redirect to forward users from the old version (appearing in web search results) to the new version. 

## Type of change

Select the type of change that you're making:

- [x ] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

