### PR TITLE
Updating CLC doc redirect and search config for 5.2 release.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -19,8 +19,8 @@
 # Redirect latest-dev clc alias to the latest-dev version
 # TODO:/clc/latest-dev/*  /clc/{snapshot}/:splat 200!
 
-# Redirect latest clc alias to the latestversion
-# TODO:/clc/latest/*  /clc/5.2/:splat 200!
+# Redirect latest clc alias to the latest version
+/clc/latest/*  /clc/5.2/:splat 200!
 
 # Redirect renamed beta version to the currecnt beta version
 /clc/5.2.0-beta-3/* /clc/5.2-beta-3/:splat 200!

--- a/search-config.json
+++ b/search-config.json
@@ -155,6 +155,18 @@
     {
       "url": "https://docs.hazelcast.com/hazelcast/(?P<version>.*?)/",
       "tags": [
+        "hazelcast-5.2-beta-2"
+      ],
+      "variables": {
+        "version": [
+          "5.2-beta-2"
+        ]
+      },
+      "selectors_key": "hz"
+    },
+    {
+      "url": "https://docs.hazelcast.com/hazelcast/(?P<version>.*?)/",
+      "tags": [
         "hazelcast-5.2-beta-1"
       ],
       "variables": {
@@ -230,6 +242,18 @@
         "cloud"
       ],
       "selectors_key": "cloud"
+    },
+    {
+      "url": "https://docs.hazelcast.com/clc/(?P<version>.*?)/",
+      "tags": [
+        "clc-5.2"
+      ],
+      "variables": {
+        "version": [
+          "5.2"
+        ]
+      },
+      "selectors_key": "command-line-client"
     },
     {
       "url": "https://docs.hazelcast.com/clc/(?P<version>.*?)/",


### PR DESCRIPTION
Also updating search config for Platform 5.2-beta-2 release.

# Description of change

Updating the search config (CLC 5.2 and Platform 5.2-beta-2)and redirects (CLC latest -> 5.2).

## Type of change

Select the type of change that you're making:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [X] Enhancement (Adds new content)

