### PR TITLE
DOCS-585 Build Failure

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -179,7 +179,7 @@ content:
     branches: master
     start_path: docs
   - url: https://github.com/hazelcast-guides/Stream-Processing-Intro
-    branches: main
+    branches: master
     start_path: docs
 ui: 
   bundle:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -182,7 +182,7 @@ content:
     branches: master
     start_path: docs
   - url: https://github.com/hazelcast-guides/Stream-Processing-Intro
-    branches: main
+    branches: master
     start_path: docs
 ui: 
   bundle:


### PR DESCRIPTION
# Description of change

Resolving build issue caused by bad indentation in production on from this commit: https://github.com/hazelcast/hazelcast-docs/commit/17b82706b128b1f4d76426829f8d1658e663bd9a.

Also changed branch of guide to `master` to match the guide repo.

## Type of change

Select the type of change that you're making:

- [ x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
- [ ] Use github checklists to create a list. When an item is solved, check the box and explain the answer.
