### PR TITLE
Fixing latest, latest-dev symbolic links for CLC.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -29,13 +29,10 @@
 /imdg/latest-dev/*  /hazelcast/5.3-snapshot/:splat 200!
 
 # Redirect latest-dev clc alias to the latest-dev version
-/clc/latest-dev/*  /clc/5.3.2-snapshot/:splat 200!
+/clc/latest-dev/*  /clc/5.3.6/:splat 200!
 
 # Redirect latest clc alias to the latest version
-/clc/latest/*  /clc/5.3.5/:splat 200!
-
-# Redirect renamed beta version to the currecnt beta version
-/clc/5.2.0-beta-3/* /clc/5.2-beta-3/:splat 200!
+/clc/latest/*  /clc/5.3.6/:splat 200!
 
 # Redirect legacy /4 version to the /4.0 version
 /imdg/4/*  /imdg/4.0/:splat 301!

--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -32,7 +32,7 @@ content:
   - url: https://github.com/hazelcast/hazelcast-platform-operator-docs
     branches: [main, v/*]
     start_path: docs
-  - url: https://github.com/hazelcast/stream-processing-fundamentals
+  - url: https://github.com/hazelcast-guides/stream-processing-fundamentals
     branches: master
     start_path: docs
   - url: https://github.com/hazelcast-guides/airline-connections


### PR DESCRIPTION
Removed CLC beta link.
Updated latest, latest-dev links to point CLC 5.3.6.