### PR TITLE
Attempt to publish latest doc updates to site

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -47,9 +47,9 @@ content:
   - url: https://github.com/hazelcast-guides/Stream-Processing-Intro
     branches: master
     start_path: docs
-  - url: https://github.com/hazelcast/cloud-docs
-    branches: [main]
-    start_paths: [docs, tutorials]
+#  - url: https://github.com/hazelcast/cloud-docs
+#    branches: [main]
+#    start_paths: [docs, tutorials]
   - url: https://github.com/hazelcast-guides/client-failover
     branches: master
     start_paths: docs

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -50,9 +50,9 @@ content:
   - url: https://github.com/hazelcast-guides/Stream-Processing-Intro
     branches: master
     start_path: docs
-  - url: https://github.com/hazelcast/cloud-docs
-    branches: [main]
-    start_paths: [docs, tutorials]
+#  - url: https://github.com/hazelcast/cloud-docs
+#    branches: [main]
+#    start_paths: [docs, tutorials]
   - url: https://github.com/hazelcast-guides/client-failover
     branches: master
     start_paths: docs


### PR DESCRIPTION
The updates since 25 January 2024, 11:58 am have not been published to the doc sites. There was a failure:

![Screenshot 2024-01-30 at 9 30 22 PM](https://github.com/hazelcast/hazelcast-docs/assets/5937333/49d64252-2635-4051-b1b7-3732668aa4f3)

This was started with the following commit:

![Screenshot 2024-01-30 at 9 31 55 PM](https://github.com/hazelcast/hazelcast-docs/assets/5937333/c61bb0b8-9e8c-4f18-8f4b-fd4f80d4a128)

This PR is an attempt to first publish the doc updates to all Hazelcast documentation subsites; the playbook changes introduced with this PR will be reverted after successful builds. Further investigation will be done in the problematic commit shown above.