### PR TITLE
Reverting cloud-docs exclusion.

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -47,9 +47,9 @@ content:
   - url: https://github.com/hazelcast-guides/Stream-Processing-Intro
     branches: master
     start_path: docs
-#  - url: https://github.com/hazelcast/cloud-docs
-#    branches: [main]
-#    start_paths: [docs, tutorials]
+  - url: https://github.com/hazelcast/cloud-docs
+    branches: [main]
+    start_paths: [docs, tutorials]
   - url: https://github.com/hazelcast-guides/client-failover
     branches: master
     start_paths: docs

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -50,9 +50,9 @@ content:
   - url: https://github.com/hazelcast-guides/Stream-Processing-Intro
     branches: master
     start_path: docs
-#  - url: https://github.com/hazelcast/cloud-docs
-#    branches: [main]
-#    start_paths: [docs, tutorials]
+  - url: https://github.com/hazelcast/cloud-docs
+    branches: [main]
+    start_paths: [docs, tutorials]
   - url: https://github.com/hazelcast-guides/client-failover
     branches: master
     start_paths: docs


### PR DESCRIPTION
With #334, latest updates are published now. This PR is to revert the workaround introduced in #334.

