### PR TITLE
Fix generate-pdfs-platform-5-4 introduced by previous commit [DEVELOP][REL-295]

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "antora --to-dir docs --fetch antora-playbook.yml && cp _redirects docs",
     "build-local": "antora --to-dir docs --fetch antora-playbook-local.yml",
     "check-links-local": "antora --fetch --to-dir test --log-level=error --log-failure-level=error --extension=@jcahills/antora-link-checker antora-playbook-local.yml",
-    "generate-pdfs-platform-5-4": "antora assembler-playbook-platform-5-5.yml",
+    "generate-pdfs-platform-5-5": "antora assembler-playbook-platform-5-5.yml",
     "generate-pdfs-platform-5-4": "antora assembler-playbook-platform-5-4.yml",
     "generate-pdfs-platform-5-3": "antora assembler-playbook-platform-5-3.yml",
     "generate-pdfs-platform-5-2": "antora assembler-playbook-platform-5-2.yml",


### PR DESCRIPTION
# Description of change

[PR-377](https://github.com/hazelcast/hazelcast-docs/pull/377) introduced 5.5 release but key was set to 5.4 and should have been 5.5

## Type of change

Select the type of change that you're making:

- [x] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)
