### PR TITLE
Fix `antora-playbook-local.yml`

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -222,7 +222,7 @@ content:
       start_path: docs
 ui:
   bundle:
-    url: ../hazelcast-docs-ui/build/ui-bundle.zip
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip
     snapshot: true
 antora:
   extensions:


### PR DESCRIPTION
The file references a path that is not guaranteed to exist, causing [build failures](https://github.com/hazelcast/hazelcast-docs/actions/runs/14109437369/job/39523960429#step:5).