### PR TITLE
Change `test external links` output format from annotations to job summary

### DIFF
--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -34,6 +34,7 @@ runs:
         - shell: ${{ env.shell }}
           run: |
             echo "temp_file=$(mktemp)" >> $GITHUB_ENV
+            echo "docs_output=test" >> $GITHUB_ENV
   
         - name: Extract links
           shell: ${{ env.shell }}
@@ -42,7 +43,7 @@ runs:
 
             # Extract all unique URLs
             # Faster than potentially checking the same link on multiple pages
-            find test -name "*.html" | while read -r file; do
+            find "${docs_output}" -name "*.html" | while read -r file; do
                 lynx -dump -listonly -nonumbers "${file}" | { grep --extended-regexp "^http" || test $? = 1; } >> "${temp_file}"
             done
   
@@ -52,6 +53,9 @@ runs:
             ${RUNNER_DEBUG:+set -o xtrace}
 
             distinct_urls=$(sort -u "${temp_file}")
+
+            echo "| URL | Status | Locations |" >> ${GITHUB_STEP_SUMMARY}
+            echo "| --- | -----: | --------- |" >> ${GITHUB_STEP_SUMMARY}
   
             while read -r url; do
                 if [[ -n "${url}" ]]; then
@@ -70,8 +74,9 @@ runs:
 
                     if [[ "${status}" -eq 404 ]]; then
                         # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
-                        locations=$(grep -rl "${url}" || true)
-                        echo "::error::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
+                        locations=$(grep -rl "${url}" "${docs_output}" || true)
+                        echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
+                        echo "| ${url} | ${status} | <ul>$(awk '{printf "<li>%s</li>", $0}' <<< "${locations}")</ul> |" >> ${GITHUB_STEP_SUMMARY}
                         found_error=1
                     else
                         echo "::debug::✅ URL '${url}' had status ${status}"

--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -34,7 +34,7 @@ runs:
         - shell: ${{ env.shell }}
           run: |
             echo "temp_file=$(mktemp)" >> $GITHUB_ENV
-            echo "docs_output=test" >> $GITHUB_ENV
+            echo "docs_output=docs" >> $GITHUB_ENV
   
         - name: Extract links
           shell: ${{ env.shell }}
@@ -49,6 +49,7 @@ runs:
   
         - name: Check links
           shell: ${{ env.shell }}
+          working-directory: ${{ env.docs_output }}
           run: |
             ${RUNNER_DEBUG:+set -o xtrace}
 
@@ -74,7 +75,7 @@ runs:
 
                     if [[ "${status}" -eq 404 ]]; then
                         # In the event of unicode control characters, grep's behaviour may be unpredictable - but lets not fail the workflow for that
-                        locations=$(grep -rl "${url}" "${docs_output}" || true)
+                        locations=$(grep -rl "${url}" || true)
                         echo "::debug::❌ URL '${url}' had status ${status} (found in ${locations})" 1>&2
                         echo "| ${url} | ${status} | <ul>$(awk '{printf "<li>%s</li>", $0}' <<< "${locations}")</ul> |" >> ${GITHUB_STEP_SUMMARY}
                         found_error=1


### PR DESCRIPTION
We use [error annotations to report the dead links found](https://github.com/hazelcast/hz-docs/actions/runs/14087424233) by `test external links`.

[GitHub has a limit of 10 error annotations](https://github.com/orgs/community/discussions/26680), which means further failures are not being reported.

Converted the output to a markdown-formatted job summary table instead.

[Example output](https://github.com/hazelcast/hazelcast-docs/actions/runs/14124545567).
