### PR TITLE
Remove relocated Hazelcast guides

### DIFF
--- a/antora-playbook-local.yml
+++ b/antora-playbook-local.yml
@@ -202,24 +202,6 @@ content:
       #    - url: https://github.com/hazelcast/management-center
       #      branches: [master, 5.1.4, 5.2.1, 5.3.4, 5.4.1, 5.5.2, 5.6.0]
       #      start_path: antora
-    - url: https://github.com/hazelcast-guides/csharp-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/python-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/java-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/nodejs-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/go-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/cpp-client-getting-started
-      branches: master
-      start_path: docs
 ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -212,24 +212,6 @@ content:
     - url: https://github.com/hazelcast/management-center
       branches: [master, 5.1.4, 5.2.1, 5.3.4, 5.4.1, 5.5.2, 5.6.0, 5.7.0]
       start_path: antora
-    - url: https://github.com/hazelcast-guides/csharp-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/python-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/java-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/nodejs-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/go-client-getting-started
-      branches: master
-      start_path: docs
-    - url: https://github.com/hazelcast-guides/cpp-client-getting-started
-      branches: master
-      start_path: docs
 ui:
   bundle:
     url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip


### PR DESCRIPTION
The "getting started" guides were migrated to `hz-docs` in https://github.com/hazelcast/hz-docs/pull/1522 and therefore no longer need to be in the playbook.