### PR TITLE
Remove top-level `env` from GitHub composite actions

### DIFF
--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -4,11 +4,6 @@ inputs:
   SLACK_WEBHOOK:
     required: true
 
-env:
-    # Not possible to set this as a default
-    # https://github.com/orgs/community/discussions/46670
-    shell: bash
-
 runs:
     using: composite
 
@@ -20,24 +15,24 @@ runs:
         #     cache: 'npm'
 
         - name: Install Lynx
-          shell: ${{ env.shell }}
+          shell: bash
           run: |
             sudo apt-get update
             sudo apt-get install -y lynx
   
         - name: Build documentation
-          shell: ${{ env.shell }}
+          shell: bash
           run: |
             npm install
             npm run-script build-local
   
-        - shell: ${{ env.shell }}
+        - shell: bash
           run: |
             echo "temp_file=$(mktemp)" >> $GITHUB_ENV
             echo "docs_output=docs" >> $GITHUB_ENV
   
         - name: Extract links
-          shell: ${{ env.shell }}
+          shell: bash
           run: |
             ${RUNNER_DEBUG:+set -o xtrace}
 
@@ -48,7 +43,7 @@ runs:
             done
   
         - name: Check links
-          shell: ${{ env.shell }}
+          shell: bash
           working-directory: ${{ env.docs_output }}
           run: |
             ${RUNNER_DEBUG:+set -o xtrace}


### PR DESCRIPTION
tl;dr - it doesn't work

In composite actions, a `shell` _must_ be specified. To avoid duplication, this was centralised to an `env` variable.

However, GitHub [doesn't support this](https://github.com/orgs/community/discussions/51280) - for example, in [this job](https://github.com/hazelcast/hazelcast-go-client/actions/runs/15848149662/job/44674983175) the output of `${{ env.shell }}` is blank.

It _appeared_ to work because if the specified `shell` is empty, it uses the default shell of the executing runner - and all of our executions were setting `bash` on Linux/Mac or `pwsh` on Windows anyway so the net effect is the same.

This bug appeared when a `bash` composite action failed to resolve `bash` commands on a Windows runner - because it was actually running in an (implicit) `pwsh` shell.