### PR TITLE
Relabel `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT` [CTT-504]

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -14,7 +14,7 @@
 /hazelcast/latest/*  /hazelcast/5.5/:splat 200!
 
 # Redirect latest-dev hazelcast alias to the latest-dev version
-/hazelcast/latest-dev/*  /hazelcast/6.0-snapshot/:splat 200!
+/hazelcast/latest-dev/*  /hazelcast/5.6-snapshot/:splat 200!
 
 # Redirect latest operator alias to the latest version
 /operator/latest/*  /operator/5.15/:splat 200!

--- a/search-config.json
+++ b/search-config.json
@@ -107,11 +107,11 @@
     {
       "url": "https://docs.hazelcast.com/hazelcast/(?P<version>.*?)/",
       "tags": [
-        "hazelcast-6.0-snapshot"
+        "hazelcast-5.6-snapshot"
       ],
       "variables": {
         "version": [
-          "6.0-snapshot"
+          "5.6-snapshot"
         ]
       },
       "selectors_key": "hz"


### PR DESCRIPTION
Renames the version on `master` from `6.0-SNAPSHOT` to `5.6-SNAPSHOT`.

Supports https://github.com/hazelcast/hazelcast-mono/pull/4852

Fixes: [CTT-504](https://hazelcast.atlassian.net/browse/CTT-504)

[CTT-504]: https://hazelcast.atlassian.net/browse/CTT-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ