### PR TITLE
MC-3148 - redicrect 6.0.1 CLC4MC link

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -47,6 +47,7 @@
 # Temporary 307 redirects so can be changed later once released
 /clc/5.5.2/* /clc/5.5.0/:splat 307!
 /clc/6.0.0/* /clc/5.5.0/:splat 307!
+/clc/6.0.1/* /clc/5.5.1/:splat 307!
 
 # Redirect legacy /4 version to the /4.0 version
 /imdg/4/*  /imdg/4.0/:splat 301!
@@ -67,4 +68,3 @@
 /management-center/5.0.4/*  /management-center/5.0/:splat 301!
 /management-center/5.1.1/*  /management-center/5.1/:splat 301!
 /management-center/5.1.2/*  /management-center/5.1/:splat 301!
-


### PR DESCRIPTION
# Description of change

Redirect CLC4MC 6.0.1 to latest CLC version, 5.5.1, due to bad links from MC

## Type of change

Select the type of change that you're making:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [ ] Enhancement (Adds new content)

