### PR TITLE
Use centralised Slack notification to avoid (deprecated) `8398a7/action-slack`

### DIFF
--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -81,12 +81,8 @@ runs:
             fi
 
         - name: Slack notification
-          uses: 8398a7/action-slack@v3
+          uses: hazelcast/docker-actions/slack-notification@master
           if: failure() && github.event_name == 'schedule'
           with:
-            status: failure
-            fields: workflow
-            text: "👎 Test external links failed - ⛓️‍💥 dead link(s) found ⛓️‍💥."
-            channel: "#docs-notifications"
-          env:
-            SLACK_WEBHOOK_URL: ${{ inputs.SLACK_WEBHOOK }}
+            slack-webhook-url: ${{ inputs.SLACK_WEBHOOK }}
+            slack-channel: "#docs-notifications"

--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -58,12 +58,8 @@ runs:
       run: ./node_modules/.bin/check-orphan-pages -d ${{ inputs.orphan-checker-directory }} --log-failure-level ${{ inputs.orphan-checker-log-failure-level }}
 
     - name: Slack notification
-      uses: 8398a7/action-slack@v3
+      uses: hazelcast/docker-actions/slack-notification@master
       if: failure() && inputs.slack-webhook-url != ''
       with:
-       status: failure
-       fields: repo,job,workflow
-       text: "👎 Validate docs failed - ⛓️‍💥 broken internal links or ASCIIDOC syntax errors found ⛓️‍💥."
-       channel: "#docs-notifications"
-      env:
-       SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+       slack-webhook-url: ${{ inputs.SLACK_WEBHOOK }}
+       slack-channel: "#docs-notifications"


### PR DESCRIPTION
The action is now archived - https://github.com/8398a7/action-slack - "use at own risk".

Update to use `docker-actions` implementations to remove explicit references to `8398a7/action-slack`.

Fixes: [DI-767](https://hazelcast.atlassian.net/browse/DI-767)

[DI-767]: https://hazelcast.atlassian.net/browse/DI-767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ