### PR TITLE
Add Platform 5.7.0 and MC 5.11.0 playbooks [REL-1869]

### DIFF
--- a/assembler-playbook-mc-5.11.yml
+++ b/assembler-playbook-mc-5.11.yml
@@ -1,0 +1,30 @@
+site:
+  title: Documentation
+  url: https:/docs.hazelcast.com
+content:
+  sources:
+  - url: https://github.com/hazelcast/management-center-docs
+    branches: [v/5.11]
+    start_path: docs
+antora:
+  extensions:
+  - '@antora/pdf-extension'
+ui:
+  bundle:
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
+    snapshot: true
+asciidoc:
+  attributes:
+    # Download images from kroki at build time (does not work for inline images)
+    kroki-fetch-diagram: true
+    idprefix: ''
+    # Separate anchor link names by dashes
+    idseparator: '-'
+    # Filter out content that doesn't apply to PDF such as embedded scripts
+    backend-pdf: true
+    hazelcast-cloud: Cloud
+    page-cloud-console: https://cloud.hazelcast.com/
+  extensions:
+    - ./node_modules/hazelcast-docs-tools/antora-macro/tabs-block.js
+    - ./node_modules/hazelcast-docs-tools/antora-macro/swagger-ui-block-macro.js
+    - asciidoctor-kroki

--- a/assembler-playbook-platform-5-7.yml
+++ b/assembler-playbook-platform-5-7.yml
@@ -4,7 +4,7 @@ site:
 content:
   sources:
   - url: https://github.com/hazelcast/hz-docs
-    branches: [v/5.7] # cut from v/5.6 to fix PDF errors which will not be merged to 'main'
+    branches: [5-7-pdf-fix] # cut from v/5.7 to fix PDF errors which will not be merged to 'main'
     start_path: docs
 antora:
   extensions:

--- a/assembler-playbook-platform-5-7.yml
+++ b/assembler-playbook-platform-5-7.yml
@@ -1,0 +1,30 @@
+site:
+  title: Documentation
+  url: https:/docs.hazelcast.com
+content:
+  sources:
+  - url: https://github.com/hazelcast/hz-docs
+    branches: [v/5.7] # cut from v/5.6 to fix PDF errors which will not be merged to 'main'
+    start_path: docs
+antora:
+  extensions:
+  - '@antora/pdf-extension'
+ui:
+  bundle:
+    url: https://github.com/hazelcast/hazelcast-docs-ui/releases/latest/download/ui-bundle.zip #../hazelcast-docs-ui/build/ui-bundle.zip
+    snapshot: true
+asciidoc:
+  attributes:
+    # Download images from kroki at build time (does not work for inline images)
+    kroki-fetch-diagram: true
+    idprefix: ''
+    # Separate anchor link names by dashes
+    idseparator: '-'
+    # Filter out content that doesn't apply to PDF such as embedded scripts
+    backend-pdf: true
+    hazelcast-cloud: Cloud
+    page-cloud-console: https://cloud.hazelcast.com/
+  extensions:
+    - ./node_modules/hazelcast-docs-tools/antora-macro/tabs-block.js
+    - ./node_modules/hazelcast-docs-tools/antora-macro/swagger-ui-block-macro.js
+    - asciidoctor-kroki

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "antora --to-dir docs --fetch antora-playbook.yml && cp _redirects docs && cp llms.txt docs",
     "build-local": "antora --to-dir docs --fetch antora-playbook-local.yml && cp _redirects docs && cp llms.txt docs",
+    "generate-pdfs-platform-5-7": "antora assembler-playbook-platform-5-7.yml",
     "generate-pdfs-platform-5-6": "antora assembler-playbook-platform-5-6.yml",
     "generate-pdfs-platform-5-5": "antora assembler-playbook-platform-5-5.yml",
     "generate-pdfs-platform-5-4": "antora assembler-playbook-platform-5-4.yml",
@@ -14,6 +15,7 @@
     "generate-pdfs-platform-5-2": "antora assembler-playbook-platform-5-2.yml",
     "generate-pdfs-platform-5-1": "antora assembler-playbook-platform-5-1.yml",
     "generate-pdfs-platform-5-0": "antora assembler-playbook-platform-5-0.yml",
+    "generate-pdfs-mc-5-11": "antora assembler-playbook-mc-5.11.yml",
     "generate-pdfs-mc-5-9": "antora assembler-playbook-mc-5.9.yml",
     "generate-pdfs-mc-5-5": "antora assembler-playbook-mc-5.5.yml",
     "generate-pdfs-mc-5-4": "antora assembler-playbook-mc-5.4.yml",


### PR DESCRIPTION
# Description of change

Add Hazelcast 5.7.0 and Management Center 5.11.0 playbooks for PDF generation

This is accompanied by PDF fixes in `hz-docs` in a separate branch https://github.com/hazelcast/hz-docs/tree/5-7-pdf-fix
The `v/5.7` should be not updated; hence, separate branch cut from `v/5.7` and pointed from [assembler-playbook-platform-5-7.yml](https://github.com/hazelcast/hazelcast-docs/compare/main...add-5-7-playbooks#diff-ba90146f5707d63b7598dbc70f4680ea34ab7f109b2d1f4a22565d6c1fdf85a3R7)

## Type of change

Select the type of change that you're making:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Open Questions and Pre-Merge TODOs
None

Fixes https://hazelcast.atlassian.net/browse/REL-1869
