### PR TITLE
Use non-default token for builds to ensure cross-org repo accessibility

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,8 +1,8 @@
 name: Build and deploy
 
 on:
-#  push:
-#    branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
       - name: Build site
         run: npm run build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Deploy to Netlify
         run: npx netlify-cli deploy --prod --dir=docs

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,8 +1,8 @@
 name: Build and deploy
 
 on:
-  push:
-    branches: [main]
+#  push:
+#    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The workflow introduced in https://github.com/hazelcast/hazelcast-docs/pull/527 uses the default token, whose access is restricted to the workflow the action is executing inside of, hence when used to access other repos [it errors](https://github.com/hazelcast/hazelcast-docs/actions/runs/26456323337/job/77891234339):
> [SWAGGER_UI] Failed to fetch https://github.com/hazelcast/hazelcast-mono/blob/master/docs/rest/modules/maintain-cluster/attachments/api-docs.yaml: Failed to fetch from GitHub API: GitHub API error: Not Found

Instead we should use a org-scoped PAT.

I have not tested this change as unsure of the side effects of executing workflow.