### PR TITLE
Configure Dependabot to update composite GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      # https://github.com/dependabot/dependabot-core/issues/6345#issuecomment-3376986288
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast-mono/pull/6282

Specifically, this has not been updated by our current configuration: https://github.com/hazelcast/hazelcast-docs/blob/dbc8a5cf9092a622c0712ab1bb0bb8aa38537b70/.github/actions/validate/action.yml#L39