### PR TITLE
Migrate _redirects and search-config.json version updates to GitHub [DI-835]

### DIFF
--- a/.github/scripts/redirects_and_search_updater.py
+++ b/.github/scripts/redirects_and_search_updater.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+
+import os
+import logging
+import urllib.request
+import re
+import json
+
+def fetch_antora_utils() -> None:
+    branch = "DI-719-migrate-antora-1"
+    target_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "antora_utils.py")
+    url_path = f"{os.getenv('GITHUB_REPOSITORY_OWNER')}/hz-docs/{branch}/.github/scripts/antora_utils.py"
+    if not os.path.exists(target_path):
+        url = f"https://raw.githubusercontent.com/{url_path}"
+        urllib.request.urlretrieve(url, filename=target_path)
+
+# `antora_utils.py is mocked in unit tests so `import` works as intended
+fetch_antora_utils()
+import antora_utils as utils
+logger: logging.Logger = utils.setup_logger(__name__)
+
+REDIRECTS_FILE: str = "_redirects"
+SEARCH_FILE: str = "search-config.json"
+
+def process_redirects(
+    master_major_minor:str,
+    rel_major_minor:str
+) -> None:
+
+    updated_latest = False
+    updated_latest_dev = False
+
+    with open(REDIRECTS_FILE, 'r+') as f:
+        lines = f.readlines()
+        
+        for idx, line in enumerate(lines):
+            if line.startswith("/hazelcast/latest/*"):
+                lines[idx] = re.sub(r"(\s+/hazelcast/)[^/]+", rf"\g<1>{rel_major_minor}", line)
+                updated_latest = True
+            elif line.startswith("/hazelcast/latest-dev/*"):
+                lines[idx] = re.sub(r"(\s+/hazelcast/)[^/]+", rf"\g<1>{master_major_minor}-snapshot", line)
+                updated_latest_dev = True
+                
+        if not updated_latest:
+            raise ValueError(f"Target pattern '/hazelcast/latest/*' was not found in {REDIRECTS_FILE}")
+        if not updated_latest_dev:
+            raise ValueError(f"Target pattern '/hazelcast/latest-dev/*' was not found in {REDIRECTS_FILE}")
+
+        f.seek(0)
+        f.writelines(lines)
+        f.truncate()
+
+    logger.debug(f"Successfully updated redirects file rules in {REDIRECTS_FILE}")
+
+def process_search_config(
+    master_major_minor:str,
+    rel_major_minor:str
+) -> None:
+
+    updated_search = False
+
+    with open(SEARCH_FILE, 'r+') as f:
+        config_data = json.load(f)
+        start_urls = config_data.get("start_urls", [])
+        new_start_urls = []
+        
+        for entry in start_urls:
+            new_start_urls.append(entry)
+            
+            if (
+                entry.get("url") and "https://docs.hazelcast.com/hazelcast/(?P<version>.*?)/" in entry.get("url")
+                and entry.get("tags")
+                and entry["tags"][0].startswith("hazelcast-")
+                and entry["tags"][0].endswith("-snapshot")
+            ):
+                matched_url = entry.get("url")
+                entry["tags"] = [f"hazelcast-{master_major_minor}-snapshot"]
+                entry["variables"]["version"] = [f"{master_major_minor}-snapshot"]
+                
+                release_entry = {
+                    "url": matched_url,
+                    "tags": [f"hazelcast-{rel_major_minor}"],
+                    "variables": {
+                        "version": [rel_major_minor]
+                    },
+                    "selectors_key": "hz"
+                }
+                new_start_urls.append(release_entry)
+                updated_search = True
+                
+        if not updated_search:
+            raise ValueError(f"Target hazelcast snapshot entry configuration block was not found in {SEARCH_FILE}")
+
+        config_data["start_urls"] = new_start_urls
+        
+        f.seek(0)
+        json.dump(config_data, f, indent=2)
+        f.truncate()
+
+    logger.debug(f"Successfully updated search configuration in {SEARCH_FILE}")
+
+def update_main(
+    master_version:str,
+    master_major_minor:str,
+    rel_major_minor:str
+) -> None:
+
+    target_base: str = "main"
+    update_branch: str = utils.checkout_branch("update_redirects_search", target_base)
+    
+    process_redirects(
+        master_major_minor=master_major_minor,
+        rel_major_minor=rel_major_minor
+    )
+
+    process_search_config(
+        master_major_minor=master_major_minor,
+        rel_major_minor=rel_major_minor
+    )
+    
+    utils.commit_changes(
+        target_base,
+        master_version,
+        [f"{REDIRECTS_FILE}", f"{SEARCH_FILE}"],
+        update_branch
+    )
+
+    utils.create_github_pr(target_base, update_branch, master_version)
+
+def update(
+    rel_major_minor:str,
+    master_version:str,
+    master_major_minor:str,
+    is_rel_major_minor:str
+) -> None:
+
+    if is_rel_major_minor == "true":
+        update_main(
+            master_version=master_version,
+            master_major_minor=master_major_minor,
+            rel_major_minor=rel_major_minor
+        )
+    else:
+        logger.info("Skip '_redirects' and 'search-config.json' updates for BETA or PATCH release")
+
+def merge_pull_requests(
+    is_rel_major_minor:str,
+    master_version:str
+) -> None:
+
+    if is_rel_major_minor == "true":
+        utils.merge_github_pr("main", master_version)
+    else:
+        logger.info("Skip '_redirects' and 'search-config.json' updates for BETA or PATCH release")

--- a/.github/scripts/test_redirects_and_search_updater.py
+++ b/.github/scripts/test_redirects_and_search_updater.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python
+import os
+import sys
+import unittest
+import types
+import logging
+import json
+import re
+from unittest.mock import patch, MagicMock
+
+def initialize_test_environment() -> None:
+    if "antora_utils" not in sys.modules:
+        class DynamicMockModule(types.ModuleType):
+            def __getattr__(self, name):
+                if name == "setup_logger":
+                    return lambda name: logging.getLogger(name)
+                return MagicMock()
+        sys.modules["antora_utils"] = DynamicMockModule("antora_utils")
+
+    global updater
+    with patch("urllib.request.urlretrieve"):
+        import redirects_and_search_updater as updater
+
+initialize_test_environment()
+
+class DynamicFileSimulator:
+    def __init__(self, redirects_content: str, search_content: str):
+        self.files = {
+            "_redirects": redirects_content,
+            "search-config.json": search_content
+        }
+
+    def open_stream(self, file_path: str, mode: str):
+        return VirtualFileContext(self, file_path, mode)
+
+class VirtualFileContext:
+    def __init__(self, factory: DynamicFileSimulator, file_path: str, mode: str):
+        self.factory = factory
+        self.file_path = file_path
+        self.mode = mode
+        self.read_done = False
+        self.local_buffer = []
+
+    def read(self, *args, **kwargs) -> str:
+        if ("r" in self.mode or "+" in self.mode) and not self.read_done:
+            self.read_done = True
+            return self.factory.files[self.file_path]
+        return ""
+
+    def readlines(self) -> list:
+        content = self.read()
+        if content:
+            return [line + "\n" if not line.endswith("\n") else line for line in content.splitlines()]
+        return []
+
+    def write(self, data: str) -> int:
+        self.local_buffer.append(data)
+        return len(data)
+
+    def writelines(self, lines: list) -> None:
+        for line in lines:
+            self.write(line)
+
+    def seek(self, position: int, *args, **kwargs) -> None:
+        if position == 0:
+            self.local_buffer = []
+            self.read_done = False
+
+    def truncate(self, *args, **kwargs) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if ("w" in self.mode or "+" in self.mode) and self.local_buffer:
+            self.factory.files[self.file_path] = "".join(self.local_buffer)
+
+
+class TestRedirectsAndSearchUpdater(unittest.TestCase):
+
+    def get_redirects_template(self) -> str:
+        return """# Standard Base Aliases
+
+/hazelcast/latest/*  /hazelcast/5.7/:splat 307!  
+
+/hazelcast/latest-dev/*  /hazelcast/5.8-snapshot/:splat 307!
+
+# Secondary Static Routes
+
+/cloud/latest/*  /cloud/default/:splat 302!
+"""
+
+    def get_search_template(self) -> str:
+        docs_url: str = "https://docs.hazelcast.com/hazelcast/(?P<version>.*?)/"
+        return json.dumps({
+            "index_name": "prod_hazelcast_docs",
+            "start_urls": [
+                {
+                    "url": "https://hazelcast.com",
+                    "tags": ["cloud"],
+                    "selectors_key": "cloud"
+                },
+                {
+                    "url": docs_url,
+                    "page_rank": 1,
+                    "tags": ["hazelcast-5.8-snapshot"],
+                    "variables": {
+                        "version": ["5.8-snapshot"]
+                    },
+                    "selectors_key": "hz"
+                },
+                {
+                    "url": docs_url,
+                    "tags": ["hazelcast-5.7"],
+                    "variables": {
+                        "version": ["5.7"]
+                    },
+                    "selectors_key": "hz"
+                },
+                {
+                    "url": "https://docs.hazelcast.com/management-center/(?P<version>.*?)/",
+                    "tags": ["management-center-5.12-snapshot"],
+                    "variables": {
+                        "version": ["5.12-snapshot"]
+                    },
+                    "selectors_key": "mc"
+                }
+            ],
+            "custom_settings": {
+                "distinct": True
+            }
+        }, indent=2)
+
+    @patch("builtins.open")
+    def test_process_redirects(self, mock_open) -> None:
+        simulator = DynamicFileSimulator(self.get_redirects_template(), self.get_search_template())
+        mock_open.side_effect = simulator.open_stream
+
+        updater.process_redirects(master_major_minor="5.9", rel_major_minor="5.8")
+
+        final_redirects = simulator.files["_redirects"]
+        
+        self.assertTrue(final_redirects.startswith("# Standard Base Aliases\n"))
+        self.assertTrue(final_redirects.endswith("# Secondary Static Routes\n\n/cloud/latest/*  /cloud/default/:splat 302!\n"))
+        
+        self.assertRegex(final_redirects, r"/hazelcast/latest/\*\s+/hazelcast/5\.8/")
+        self.assertRegex(final_redirects, r"/hazelcast/latest-dev/\*\s+/hazelcast/5\.9-snapshot/")
+
+    @patch("builtins.open")
+    def test_process_redirects_failure(self, mock_open) -> None:
+        bad_redirects_template = """# Missing target patterns entirely
+/cloud/latest/*  /cloud/default/:splat 302!
+"""
+        simulator = DynamicFileSimulator(bad_redirects_template, self.get_search_template())
+        mock_open.side_effect = simulator.open_stream
+
+        with self.assertRaises(ValueError) as context:
+            updater.process_redirects(master_major_minor="5.9", rel_major_minor="5.8")
+            
+        self.assertIn("Target pattern '/hazelcast/latest/*' was not found", str(context.exception))
+
+    @patch("builtins.open")
+    def test_process_search_config(self, mock_open) -> None:
+        simulator = DynamicFileSimulator(self.get_redirects_template(), self.get_search_template())
+        mock_open.side_effect = simulator.open_stream
+
+        updater.process_search_config(master_major_minor="5.9", rel_major_minor="5.8")
+
+        final_search = json.loads(simulator.files["search-config.json"])
+
+        self.assertEqual(final_search["index_name"], "prod_hazelcast_docs")
+        self.assertTrue(final_search["custom_settings"]["distinct"])
+
+        urls = final_search["start_urls"]
+        self.assertEqual(len(urls), 5)
+
+        self.assertEqual(urls[0]["selectors_key"], "cloud")
+        self.assertEqual(urls[4]["selectors_key"], "mc")
+
+        self.assertEqual(urls[1]["tags"], ["hazelcast-5.9-snapshot"])
+        self.assertEqual(urls[1]["variables"]["version"], ["5.9-snapshot"])
+        self.assertEqual(urls[1]["page_rank"], 1)
+
+        self.assertEqual(urls[2]["tags"], ["hazelcast-5.8"])
+        self.assertEqual(urls[2]["variables"]["version"], ["5.8"])
+        self.assertEqual(urls[2]["selectors_key"], "hz")
+        self.assertNotIn("page_rank", urls[2])
+
+        self.assertEqual(urls[3]["tags"], ["hazelcast-5.7"])
+        self.assertEqual(urls[3]["variables"]["version"], ["5.7"])
+        self.assertEqual(urls[3]["selectors_key"], "hz")
+
+        self.assertEqual(urls[4]["tags"], ["management-center-5.12-snapshot"])
+        self.assertEqual(urls[4]["variables"]["version"], ["5.12-snapshot"])
+        self.assertEqual(urls[4]["selectors_key"], "mc")
+
+    @patch("builtins.open")
+    def test_process_search_config_failure(self, mock_open) -> None:
+        bad_search_template = json.dumps({
+            "index_name": "prod_hazelcast_docs",
+            "start_urls": [
+                {
+                    "url": "https://hazelcast.com",
+                    "tags": ["cloud"],
+                    "selectors_key": "cloud"
+                }
+            ]
+        })
+        simulator = DynamicFileSimulator(self.get_redirects_template(), bad_search_template)
+        mock_open.side_effect = simulator.open_stream
+
+        with self.assertRaises(ValueError) as context:
+            updater.process_search_config(master_major_minor="5.9", rel_major_minor="5.8")
+            
+        self.assertIn("Target hazelcast snapshot entry configuration block was not found", str(context.exception))
+
+    def test_update_is_rel_major_minor_true(self) -> None:
+        simulator = DynamicFileSimulator(self.get_redirects_template(), self.get_search_template())
+
+        with patch("builtins.open", side_effect=simulator.open_stream) as mock_open, \
+             patch("antora_utils.checkout_branch", return_value="update_search_branch_123") as mock_checkout, \
+             patch("antora_utils.commit_changes") as mock_commit, \
+             patch("antora_utils.create_github_pr") as mock_pr:
+
+            updater.update(
+                rel_major_minor="5.8",
+                master_version="5.9.0-SNAPSHOT",
+                master_major_minor="5.9",
+                is_rel_major_minor="true"
+            )
+
+            mock_checkout.assert_called_once_with("update_redirects_search", "main")
+            mock_commit.assert_called_once_with("main", "5.9.0-SNAPSHOT", ["_redirects", "search-config.json"], "update_search_branch_123")
+            mock_pr.assert_called_once_with("main", "update_search_branch_123", "5.9.0-SNAPSHOT")
+
+            final_redirects = simulator.files["_redirects"]
+            self.assertRegex(final_redirects, r"/hazelcast/latest/\*\s+/hazelcast/5\.8/")
+
+    def test_update_is_rel_major_minor_false(self) -> None:
+        simulator = DynamicFileSimulator(self.get_redirects_template(), self.get_search_template())
+
+        with patch("builtins.open", side_effect=simulator.open_stream), \
+             patch("antora_utils.checkout_branch") as mock_checkout, \
+             patch("redirects_and_search_updater.logger.info") as mock_info:
+
+            updater.update(
+                rel_major_minor="5.8",
+                master_version="5.8.1-SNAPSHOT",
+                master_major_minor="5.8",
+                is_rel_major_minor="false"
+            )
+
+            mock_checkout.assert_not_called()
+            mock_info.assert_called_once_with("Skip '_redirects' and 'search-config.json' updates for BETA or PATCH release")
+
+    @patch("antora_utils.merge_github_pr")
+    def test_merge_pull_requests_true(self, mock_merge) -> None:
+        updater.merge_pull_requests(
+            is_rel_major_minor="true",
+            master_version="5.9.0-SNAPSHOT"
+        )
+        mock_merge.assert_called_once_with("main", "5.9.0-SNAPSHOT")
+
+    @patch("antora_utils.merge_github_pr")
+    def test_merge_pull_requests_false(self, mock_merge) -> None:
+        with patch("redirects_and_search_updater.logger.info") as mock_info:
+            updater.merge_pull_requests(
+                is_rel_major_minor="false",
+                master_version="5.8.2-SNAPSHOT"
+            )
+
+        mock_merge.assert_not_called()
+        mock_info.assert_called_once_with("Skip '_redirects' and 'search-config.json' updates for BETA or PATCH release")
+
+if __name__ == "__main__":
+    unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -31,6 +31,7 @@ jobs:
       id-token: write
       contents: write
     steps:
+        # https://github.com/Codex-/return-dispatch#receiving-repository-action
       - name: Logging distinct ID (${{ inputs.distinct_id }})
         run: echo "${DISTINCT_ID}"
         env:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -2,6 +2,7 @@ name: Package Release
 run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
 
 on:
+  # Called from release orchestrator
   workflow_dispatch:
     inputs:
       VERSION:
@@ -24,24 +25,17 @@ on:
         required: false
 
 jobs:
-  prepare:
-    runs-on: ubuntu-slim
+  package:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - name: Logging distinct ID (${{ inputs.distinct_id }})
         run: echo "${DISTINCT_ID}"
         env:
           DISTINCT_ID: ${{ inputs.distinct_id }}
 
-  package:
-    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
-    needs: prepare
-    environment:
-      name: ${{ inputs.ENVIRONMENT }}
-      deployment: false
-    permissions:
-      id-token: write
-      contents: write
-    steps:
       - name: Checkout `release` branch
         uses: actions/checkout@v7
         with:
@@ -54,12 +48,10 @@ jobs:
 
       - name: Get release info
         id: get-rel-info
-        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        uses: hazelcast/mono-actions/get-release-info@DI-719-migrate-antora-1
         with:
           release-version: ${{ inputs.VERSION }}
-          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
           github-token: ${{ secrets.GH_TOKEN }}
-          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
 
       - name: Configure git
         working-directory: ${{ inputs.VERSION }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,89 @@
+name: Package Release
+run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: 'The version to build (e.g. `5.4.1`)'
+        required: true
+      RELEASE_TYPE:
+        description: 'What should be built'
+        required: true
+        type: choice
+        options:
+          - ALL
+          - OSS
+          - EE
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: environment
+      distinct_id:
+        description: 'Required exclusively for automated execution to track status of workflow execution'
+        required: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Logging distinct ID (${{ inputs.distinct_id }})
+        run: echo "${DISTINCT_ID}"
+        env:
+          DISTINCT_ID: ${{ inputs.distinct_id }}
+
+  package:
+    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
+    needs: prepare
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
+      deployment: false
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Checkout `release` branch
+        uses: actions/checkout@v7
+        with:
+          path: ${{ inputs.VERSION }}
+
+      - name: Checkout `main` automation scripts
+        uses: actions/checkout@v7
+        with:
+          path: src-scripts
+
+      - name: Get release info
+        id: get-rel-info
+        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        with:
+          release-version: ${{ inputs.VERSION }}
+          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
+          github-token: ${{ secrets.GH_TOKEN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+
+      - name: Configure git
+        working-directory: ${{ inputs.VERSION }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Update `_redirects` and `search-config.json` with Pull Requests
+        shell: python
+        working-directory: ${{ inputs.VERSION }}
+        run: |
+          from os import getenv
+          import redirects_and_search_updater as redirects
+
+          redirects.update(
+              rel_major_minor=getenv("REL_MAJOR_MINOR"),
+              master_version=getenv("MASTER_VERSION"),
+              master_major_minor=getenv("MASTER_MAJOR_MINOR"),
+              is_rel_major_minor=getenv("IS_REL_MAJOR_MINOR")
+          )
+        env:
+          REL_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.rel-major-minor }}
+          MASTER_VERSION: ${{ steps.get-rel-info.outputs.master-version }}
+          MASTER_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.master-major-minor }}
+          IS_REL_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.is-rel-major-minor }}
+          PYTHONPATH: ${{ github.workspace }}/src-scripts/.github/scripts
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -2,6 +2,7 @@ name: Promote Release
 run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
 
 on:
+  # Called from release orchestrator
   workflow_dispatch:
     inputs:
       VERSION:
@@ -24,36 +25,27 @@ on:
         required: false
 
 jobs:
-  prepare:
+  promote:
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
     steps:
       - name: Logging distinct ID (${{ inputs.distinct_id }})
         run: echo "${DISTINCT_ID}"
         env:
           DISTINCT_ID: ${{ inputs.distinct_id }}
 
-  promote:
-    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
-    needs: prepare
-    environment:
-      name: ${{ inputs.ENVIRONMENT }}
-      deployment: false
-    permissions:
-      contents: read
-      id-token: write
-      pull-requests: write
-    steps:
       - name: Checkout `main` automation scripts
         uses: actions/checkout@v7
 
       - name: Get release info
         id: get-rel-info
-        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        uses: hazelcast/mono-actions/get-release-info@DI-719-migrate-antora-1
         with:
           release-version: ${{ inputs.VERSION }}
-          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
           github-token: ${{ secrets.GH_TOKEN }}
-          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
 
       - name: Merge Redirects Pull Requests
         shell: python

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -32,6 +32,7 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
+        # https://github.com/Codex-/return-dispatch#receiving-repository-action
       - name: Logging distinct ID (${{ inputs.distinct_id }})
         run: echo "${DISTINCT_ID}"
         env:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,72 @@
+name: Promote Release
+run-name: ${{ github.workflow }} (`${{ inputs.VERSION }}`@${{ inputs.ENVIRONMENT }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: 'The version to promote (e.g. `5.4.1`)'
+        required: true
+      RELEASE_TYPE:
+        description: 'What should be promoted'
+        required: true
+        type: choice
+        options:
+          - ALL
+          - OSS
+          - EE
+      ENVIRONMENT:
+        description: 'Environment to use'
+        required: true
+        type: environment
+      distinct_id:
+        description: 'Required exclusively for automated execution to track status of workflow execution'
+        required: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Logging distinct ID (${{ inputs.distinct_id }})
+        run: echo "${DISTINCT_ID}"
+        env:
+          DISTINCT_ID: ${{ inputs.distinct_id }}
+
+  promote:
+    runs-on: ${{ github.event.repository.fork && 'ubuntu-latest' || 'ubicloud-standard-2' }}
+    needs: prepare
+    environment:
+      name: ${{ inputs.ENVIRONMENT }}
+      deployment: false
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Checkout `main` automation scripts
+        uses: actions/checkout@v7
+
+      - name: Get release info
+        id: get-rel-info
+        uses: hazelcast/mono-actions/release-info@DI-719-migrate-antora-1
+        with:
+          release-version: ${{ inputs.VERSION }}
+          jfrog-files-repo: ${{ vars.JFROG_PREPROD_FILES_REPO }}
+          github-token: ${{ secrets.GH_TOKEN }}
+          aws-role-to-assume: ${{ vars.AWS_HAZELCAST_OIDC_GITHUB_ACTIONS_ROLE_ARN }}
+
+      - name: Merge Redirects Pull Requests
+        shell: python
+        run: |
+          from os import getenv
+          import redirects_and_search_updater as redirects
+
+          redirects.merge_pull_requests(
+              is_rel_major_minor=getenv("IS_REL_MAJOR_MINOR"),
+              master_version=getenv("MASTER_VERSION")
+          )
+        env:
+          IS_REL_MAJOR_MINOR: ${{ steps.get-rel-info.outputs.is-rel-major-minor }}
+          MASTER_VERSION: ${{ steps.get-rel-info.outputs.master-version }}
+          PYTHONPATH: ${{ github.workspace }}/.github/scripts
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -5,9 +5,9 @@ on:
     branches:
       - main
     paths:
-      - '.github/scripts/**'
-      - '.github/workflows/package-release.yml'
-      - '.github/workflows/promote-release.yml'
+      - '.github/scripts/*.py'
+      - '.github/workflows/package.yml'
+      - '.github/workflows/promote.yml'
 
 jobs:
   test:

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -4,25 +4,20 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize]
     paths:
       - '.github/scripts/**'
       - '.github/workflows/package-release.yml'
       - '.github/workflows/promote-release.yml'
-  workflow_dispatch:
 
 jobs:
   test:
+    # Ignore automated release PR branches
+    if: ${{ !startsWith(github.head_ref, 'update_antora_') }}
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
 
       - name: Install ruamel.yaml
         run: python3 -m pip install ruamel.yaml packaging

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -19,9 +19,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Install ruamel.yaml
-        run: python3 -m pip install ruamel.yaml packaging
+      - name: Install Python packages
+        run: python3 -m pip install unittest-xml-reporting
 
       - name: Run unit tests
         run: |
-          python3 -m unittest discover -s .github/scripts -p "test_*.py"
+          python3 -m xmlrunner discover -s .github/scripts -p "test_*.py" -o test-results/
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
+        if: always()
+        with:
+          files: |
+            test-results/**/*.xml

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -1,0 +1,32 @@
+name: Run release unit tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, synchronize]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/package-release.yml'
+      - '.github/workflows/promote-release.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ruamel.yaml
+        run: python3 -m pip install ruamel.yaml packaging
+
+      - name: Run unit tests
+        run: |
+          python3 -m unittest discover -s .github/scripts -p "test_*.py"

--- a/.github/workflows/release-pr-builder.yml
+++ b/.github/workflows/release-pr-builder.yml
@@ -20,15 +20,14 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install Python packages
-        run: python3 -m pip install unittest-xml-reporting
+        run: python3 -m pip install pytest
 
       - name: Run unit tests
         run: |
-          python3 -m xmlrunner discover -s .github/scripts -p "test_*.py" -o test-results/
+          pytest .github/scripts/ --junit-xml=test-results/results.xml
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2.24.0
         if: always()
         with:
-          files: |
-            test-results/**/*.xml
+          files: test-results/results.xml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check-links:
-
+    if: ${{ !startsWith(github.head_ref, 'update_antora_') }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@
 /pdf-docs/
 Gemfile.lock
 .idea
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.env
+.pytest_cache/
+.unittest_cache/


### PR DESCRIPTION
# Description of change
Adds scripts and workflows to update Hazelcast `_redirects` and `search-config.json` version updates:


| Type | Details |
| :--- | :--- |
| **MAJOR/MINOR** | `_redirects` : updates `main` branch versions to the current `hazelcast-mono@master` POM version and release version <br>`search-config.json` : updates `main` branch `*-snapshot` version to current HZ `master` and adds new release version block  |
| **PATCH/BETA** | Skipped |
| **V/BRANCH** | Skipped |

## Testing

Tested in `sandbox`

1.  `ReleaseInfo` generated via https://github.com/hazelcast/mono-actions/pull/26
2. Workflows (`package` and `promote`) triggered manually

Merged PR for `5.8.0` https://github.com/hz-devops-test/hazelcast-docs/pull/6


## Type of change

Select the type of change that you're making:

- [ ] Bug fix (Addresses an issue in existing content such as a typo)
- [x] Enhancement (Adds new content)

## Pre-Merge

- [ ] Replace all occurrences of `DI-719-migrate-antora-1` to `main`

Fixes: [DI-835](https://hazelcast.atlassian.net/browse/DI-835)

[DI-835]: https://hazelcast.atlassian.net/browse/DI-835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ