### PR TITLE
Require explicit `status` input for Slack notification action

### DIFF
--- a/.github/actions/test-external-links/action.yml
+++ b/.github/actions/test-external-links/action.yml
@@ -86,3 +86,4 @@ runs:
           with:
             slack-webhook-url: ${{ inputs.SLACK_WEBHOOK }}
             slack-channel: "#docs-notifications"
+            status: failure

--- a/.github/actions/validate/action.yml
+++ b/.github/actions/validate/action.yml
@@ -63,3 +63,4 @@ runs:
       with:
        slack-webhook-url: ${{ inputs.SLACK_WEBHOOK }}
        slack-channel: "#docs-notifications"
+       status: failure


### PR DESCRIPTION
See https://github.com/hazelcast/docker-actions/pull/79